### PR TITLE
test(notification): add comprehensive unit tests for NotificationService

### DIFF
--- a/.claude/output-styles/architect.md
+++ b/.claude/output-styles/architect.md
@@ -72,11 +72,6 @@ Once all decisions are made and the user confirms the plan is ready:
 ### Decided Approach
 [Clear description of the chosen solution at architectural level]
 
-**Why this approach:**
-- [Key reason 1]
-- [Key reason 2]
-- [Key reason 3]
-
 ### Implementation Areas
 
 #### 1. [Component/Area Name]
@@ -84,8 +79,6 @@ Once all decisions are made and the user confirms the plan is ready:
 - [High-level change in ComponentName class]
 - [New method needed in ServiceClass]
 - [Update to existing MethodName behavior]
-
-**Rationale:** [Why these changes are needed]
 
 #### 2. [Component/Area Name]
 **What needs to change:**

--- a/BookSharingApp.Tests/Helpers/TestDataBuilder.cs
+++ b/BookSharingApp.Tests/Helpers/TestDataBuilder.cs
@@ -11,6 +11,7 @@ namespace BookSharingApp.Tests.Helpers
         private static int _communityIdCounter = 1;
         private static int _shareIdCounter = 1;
         private static int _shareUserStateIdCounter = 1;
+        private static int _notificationIdCounter = 1;
 
         public static User CreateUser(
             string? id = null,
@@ -144,6 +145,32 @@ namespace BookSharingApp.Tests.Helpers
             };
         }
 
+        public static Notification CreateNotification(
+            int? id = null,
+            string? userId = null,
+            string? notificationType = null,
+            string? message = null,
+            int? shareId = null,
+            string? createdByUserId = null,
+            DateTime? createdAt = null,
+            DateTime? readAt = null)
+        {
+            var finalUserId = userId ?? "default-user";
+            var finalCreatedByUserId = createdByUserId ?? "default-creator";
+
+            return new Notification
+            {
+                Id = id ?? _notificationIdCounter++,
+                UserId = finalUserId,
+                NotificationType = notificationType ?? NotificationType.ShareStatusChanged,
+                Message = message ?? "Test notification message",
+                ShareId = shareId,
+                CreatedByUserId = finalCreatedByUserId,
+                CreatedAt = createdAt ?? DateTime.UtcNow,
+                ReadAt = readAt
+            };
+        }
+
         public static void ResetCounters()
         {
             _userIdCounter = 1;
@@ -152,6 +179,7 @@ namespace BookSharingApp.Tests.Helpers
             _communityIdCounter = 1;
             _shareIdCounter = 1;
             _shareUserStateIdCounter = 1;
+            _notificationIdCounter = 1;
         }
     }
 }

--- a/BookSharingApp.Tests/Services/CreateShareNotificationAsyncTests.cs
+++ b/BookSharingApp.Tests/Services/CreateShareNotificationAsyncTests.cs
@@ -1,0 +1,523 @@
+using BookSharingApp.Common;
+using BookSharingApp.Services;
+using BookSharingApp.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BookSharingApp.Tests.Services
+{
+    public class CreateShareNotificationAsyncTests : IDisposable
+    {
+        private readonly Mock<ILogger<NotificationService>> _loggerMock;
+
+        public CreateShareNotificationAsyncTests()
+        {
+            _loggerMock = new Mock<ILogger<NotificationService>>();
+        }
+
+        public void Dispose()
+        {
+            // Cleanup if needed
+        }
+
+        [Fact]
+        public async Task WhenLenderCreatesNotification_BorrowerIsRecipient()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                lender.Id
+            );
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.UserId.Should().Be(borrower.Id);
+        }
+
+        [Fact]
+        public async Task WhenBorrowerCreatesNotification_LenderIsRecipient()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                borrower.Id
+            );
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.UserId.Should().Be(lender.Id);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_SetsNotificationTypeCorrectly()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareDueDateChanged,
+                "Test message",
+                lender.Id
+            );
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.NotificationType.Should().Be(NotificationType.ShareDueDateChanged);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_SetsMessageCorrectly()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            var expectedMessage = "Custom test message";
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                expectedMessage,
+                lender.Id
+            );
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.Message.Should().Be(expectedMessage);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_SetsShareIdCorrectly()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                lender.Id
+            );
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.ShareId.Should().Be(share.Id);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_SetsCreatedByUserIdCorrectly()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                lender.Id
+            );
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.CreatedByUserId.Should().Be(lender.Id);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_SetsCreatedAtToUtcNow()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            var beforeTime = DateTime.UtcNow.AddSeconds(-1);
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                lender.Id
+            );
+
+            var afterTime = DateTime.UtcNow.AddSeconds(1);
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.CreatedAt.Should().BeAfter(beforeTime);
+            notification.CreatedAt.Should().BeBefore(afterTime);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_SetsReadAtToNull()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                lender.Id
+            );
+
+            // Assert
+            var notification = await context.Notifications.FirstOrDefaultAsync();
+            notification.Should().NotBeNull();
+            notification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithValidRequest_PersistsNotificationToDatabase()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                lender.Id
+            );
+
+            // Assert
+            var notificationCount = await context.Notifications.CountAsync();
+            notificationCount.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task WhenShareNotFound_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var nonExistentShareId = 999;
+
+            // Act
+            var act = async () => await notificationService.CreateShareNotificationAsync(
+                nonExistentShareId,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                "user-1"
+            );
+
+            // Assert
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("Share not found");
+        }
+
+        [Fact]
+        public async Task WhenUserNotInvolvedInShare_ThrowsUnauthorizedAccessException()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var outsider = TestDataBuilder.CreateUser(id: "outsider-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower, outsider);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            // Act
+            var act = async () => await notificationService.CreateShareNotificationAsync(
+                share.Id,
+                NotificationType.ShareStatusChanged,
+                "Test message",
+                outsider.Id
+            );
+
+            // Assert
+            await act.Should().ThrowAsync<UnauthorizedAccessException>()
+                .WithMessage("User is not involved in this share");
+        }
+    }
+}

--- a/BookSharingApp.Tests/Services/GetUnreadNotificationsAsyncTests.cs
+++ b/BookSharingApp.Tests/Services/GetUnreadNotificationsAsyncTests.cs
@@ -1,0 +1,466 @@
+using BookSharingApp.Common;
+using BookSharingApp.Services;
+using BookSharingApp.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BookSharingApp.Tests.Services
+{
+    public class GetUnreadNotificationsAsyncTests : IDisposable
+    {
+        private readonly Mock<ILogger<NotificationService>> _loggerMock;
+
+        public GetUnreadNotificationsAsyncTests()
+        {
+            _loggerMock = new Mock<ILogger<NotificationService>>();
+        }
+
+        public void Dispose()
+        {
+            // Cleanup if needed
+        }
+
+        [Fact]
+        public async Task WithUnreadNotifications_ReturnsOnlyUnreadNotifications()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            var creator = TestDataBuilder.CreateUser(id: "creator-1");
+            context.Users.AddRange(user, creator);
+            await context.SaveChangesAsync();
+
+            var unreadNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                readAt: null
+            );
+
+            // Link navigation properties to tracked entities
+            unreadNotification.User = user;
+            unreadNotification.CreatedByUser = creator;
+
+            context.Notifications.Add(unreadNotification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(user.Id);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(unreadNotification.Id);
+        }
+
+        [Fact]
+        public async Task WithReadAndUnreadNotifications_ExcludesReadNotifications()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            var creator = TestDataBuilder.CreateUser(id: "creator-1");
+            context.Users.AddRange(user, creator);
+            await context.SaveChangesAsync();
+
+            var unreadNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                readAt: null
+            );
+            unreadNotification.User = user;
+            unreadNotification.CreatedByUser = creator;
+
+            var readNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                readAt: DateTime.UtcNow.AddHours(-1)
+            );
+            readNotification.User = user;
+            readNotification.CreatedByUser = creator;
+
+            context.Notifications.AddRange(unreadNotification, readNotification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(user.Id);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(unreadNotification.Id);
+            result.Should().NotContain(n => n.Id == readNotification.Id);
+        }
+
+        [Fact]
+        public async Task WithNoUnreadNotifications_ReturnsEmptyList()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var readNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                readAt: DateTime.UtcNow
+            );
+            context.Notifications.Add(readNotification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(user.Id);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task WithMultipleUsers_ReturnsOnlySpecifiedUserNotifications()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user1 = TestDataBuilder.CreateUser(id: "user-1");
+            var user2 = TestDataBuilder.CreateUser(id: "user-2");
+            var creator = TestDataBuilder.CreateUser(id: "creator-1");
+            context.Users.AddRange(user1, user2, creator);
+            await context.SaveChangesAsync();
+
+            var user1Notification = TestDataBuilder.CreateNotification(
+                userId: user1.Id,
+                createdByUserId: creator.Id,
+                readAt: null
+            );
+            user1Notification.User = user1;
+            user1Notification.CreatedByUser = creator;
+
+            var user2Notification = TestDataBuilder.CreateNotification(
+                userId: user2.Id,
+                createdByUserId: creator.Id,
+                readAt: null
+            );
+            user2Notification.User = user2;
+            user2Notification.CreatedByUser = creator;
+
+            context.Notifications.AddRange(user1Notification, user2Notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(user1.Id);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(user1Notification.Id);
+            result.Should().NotContain(n => n.Id == user2Notification.Id);
+        }
+
+        [Fact]
+        public async Task WithMultipleNotifications_ReturnsOrderedByCreatedAtDescending()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            var creator = TestDataBuilder.CreateUser(id: "creator-1");
+            context.Users.AddRange(user, creator);
+            await context.SaveChangesAsync();
+
+            var oldestNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                createdAt: DateTime.UtcNow.AddHours(-3),
+                readAt: null
+            );
+            oldestNotification.User = user;
+            oldestNotification.CreatedByUser = creator;
+
+            var middleNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                createdAt: DateTime.UtcNow.AddHours(-2),
+                readAt: null
+            );
+            middleNotification.User = user;
+            middleNotification.CreatedByUser = creator;
+
+            var newestNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                createdAt: DateTime.UtcNow.AddHours(-1),
+                readAt: null
+            );
+            newestNotification.User = user;
+            newestNotification.CreatedByUser = creator;
+
+            context.Notifications.AddRange(oldestNotification, middleNotification, newestNotification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(user.Id);
+
+            // Assert
+            result.Should().HaveCount(3);
+            result[0].Id.Should().Be(newestNotification.Id);
+            result[1].Id.Should().Be(middleNotification.Id);
+            result[2].Id.Should().Be(oldestNotification.Id);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_IncludesShareNavigationProperty()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: borrower.Id,
+                createdByUserId: lender.Id,
+                shareId: share.Id,
+                readAt: null
+            );
+            notification.User = borrower;
+            notification.CreatedByUser = lender;
+            notification.Share = share;
+
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(borrower.Id);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].Share.Should().NotBeNull();
+            result[0].Share!.Id.Should().Be(share.Id);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_IncludesUserBookNavigationProperty()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook();
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: borrower.Id,
+                createdByUserId: lender.Id,
+                shareId: share.Id,
+                readAt: null
+            );
+            notification.User = borrower;
+            notification.CreatedByUser = lender;
+            notification.Share = share;
+
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(borrower.Id);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].Share.Should().NotBeNull();
+            result[0].Share!.UserBook.Should().NotBeNull();
+            result[0].Share?.UserBook.Id.Should().Be(userBook.Id);
+        }
+
+        [Fact]
+        public async Task WithValidRequest_IncludesBookNavigationProperty()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+            var book = TestDataBuilder.CreateBook(title: "Test Book Title");
+
+            context.Users.AddRange(lender, borrower);
+            context.Books.Add(book);
+            await context.SaveChangesAsync();
+
+            var userBook = TestDataBuilder.CreateUserBook(
+                userId: lender.Id,
+                bookId: book.Id,
+                user: lender,
+                book: book
+            );
+            context.UserBooks.Add(userBook);
+            await context.SaveChangesAsync();
+
+            var share = TestDataBuilder.CreateShare(
+                userBookId: userBook.Id,
+                borrower: borrower.Id,
+                userBook: userBook,
+                borrowerUser: borrower
+            );
+            context.Shares.Add(share);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: borrower.Id,
+                createdByUserId: lender.Id,
+                shareId: share.Id,
+                readAt: null
+            );
+            notification.User = borrower;
+            notification.CreatedByUser = lender;
+            notification.Share = share;
+
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(borrower.Id);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].Share.Should().NotBeNull();
+            result[0].Share!.UserBook.Should().NotBeNull();
+            result[0].Share?.UserBook.Book.Should().NotBeNull();
+            result[0].Share?.UserBook.Book.Title.Should().Be("Test Book Title");
+        }
+
+        [Fact]
+        public async Task WithValidRequest_IncludesCreatedByUserNavigationProperty()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var lender = TestDataBuilder.CreateUser(id: "lender-1", firstName: "John");
+            var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+
+            context.Users.AddRange(lender, borrower);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: borrower.Id,
+                createdByUserId: lender.Id,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(borrower.Id);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].CreatedByUser.Should().NotBeNull();
+            result[0].CreatedByUser.Id.Should().Be(lender.Id);
+            result[0].CreatedByUser.FirstName.Should().Be("John");
+        }
+
+        [Fact]
+        public async Task WithMixedNotificationTypes_ReturnsAllUnreadTypes()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            var creator = TestDataBuilder.CreateUser(id: "creator-1");
+            context.Users.AddRange(user, creator);
+            await context.SaveChangesAsync();
+
+            var statusNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                readAt: null
+            );
+            statusNotification.User = user;
+            statusNotification.CreatedByUser = creator;
+
+            var dueDateNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                notificationType: NotificationType.ShareDueDateChanged,
+                readAt: null
+            );
+            dueDateNotification.User = user;
+            dueDateNotification.CreatedByUser = creator;
+
+            var messageNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                createdByUserId: creator.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                readAt: null
+            );
+            messageNotification.User = user;
+            messageNotification.CreatedByUser = creator;
+
+            context.Notifications.AddRange(statusNotification, dueDateNotification, messageNotification);
+            await context.SaveChangesAsync();
+
+            // Act
+            var result = await notificationService.GetUnreadNotificationsAsync(user.Id);
+
+            // Assert
+            result.Should().HaveCount(3);
+            result.Should().Contain(n => n.NotificationType == NotificationType.ShareStatusChanged);
+            result.Should().Contain(n => n.NotificationType == NotificationType.ShareDueDateChanged);
+            result.Should().Contain(n => n.NotificationType == NotificationType.ShareMessageReceived);
+        }
+    }
+}

--- a/BookSharingApp.Tests/Services/MarkShareChatNotificationsAsReadAsyncTests.cs
+++ b/BookSharingApp.Tests/Services/MarkShareChatNotificationsAsReadAsyncTests.cs
@@ -1,0 +1,358 @@
+using BookSharingApp.Common;
+using BookSharingApp.Services;
+using BookSharingApp.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BookSharingApp.Tests.Services
+{
+    public class MarkShareChatNotificationsAsReadAsyncTests : IDisposable
+    {
+        private readonly Mock<ILogger<NotificationService>> _loggerMock;
+
+        public MarkShareChatNotificationsAsReadAsyncTests()
+        {
+            _loggerMock = new Mock<ILogger<NotificationService>>();
+        }
+
+        public void Dispose()
+        {
+            // Cleanup if needed
+        }
+
+        [Fact]
+        public async Task WithUnreadShareMessageReceivedNotification_MarksAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task WithUnreadShareStatusChangedNotification_DoesNotMarkAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithUnreadShareDueDateChangedNotification_DoesNotMarkAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareDueDateChanged,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithMixedNotificationTypes_OnlyMarksShareMessageReceivedType()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var statusNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var dueDateNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareDueDateChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var messageNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.AddRange(statusNotification, dueDateNotification, messageNotification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedStatusNotification = await context.Notifications.FindAsync(statusNotification.Id);
+            var updatedDueDateNotification = await context.Notifications.FindAsync(dueDateNotification.Id);
+            var updatedMessageNotification = await context.Notifications.FindAsync(messageNotification.Id);
+
+            updatedStatusNotification!.ReadAt.Should().BeNull();
+            updatedDueDateNotification!.ReadAt.Should().BeNull();
+            updatedMessageNotification!.ReadAt.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task WithNotificationsForDifferentUser_DoesNotMarkAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user1 = TestDataBuilder.CreateUser(id: "user-1");
+            var user2 = TestDataBuilder.CreateUser(id: "user-2");
+            context.Users.AddRange(user1, user2);
+            await context.SaveChangesAsync();
+
+            var user1Notification = TestDataBuilder.CreateNotification(
+                userId: user1.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            var user2Notification = TestDataBuilder.CreateNotification(
+                userId: user2.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.AddRange(user1Notification, user2Notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user1.Id);
+
+            // Assert
+            var updatedUser1Notification = await context.Notifications.FindAsync(user1Notification.Id);
+            var updatedUser2Notification = await context.Notifications.FindAsync(user2Notification.Id);
+
+            updatedUser1Notification!.ReadAt.Should().NotBeNull();
+            updatedUser2Notification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithNotificationsForDifferentShare_DoesNotMarkAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var share1Notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            var share2Notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 2,
+                readAt: null
+            );
+            context.Notifications.AddRange(share1Notification, share2Notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedShare1Notification = await context.Notifications.FindAsync(share1Notification.Id);
+            var updatedShare2Notification = await context.Notifications.FindAsync(share2Notification.Id);
+
+            updatedShare1Notification!.ReadAt.Should().NotBeNull();
+            updatedShare2Notification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithReadChatNotifications_DoesNotUpdateReadAt()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var originalReadTime = DateTime.UtcNow.AddHours(-2);
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: originalReadTime
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().Be(originalReadTime);
+        }
+
+        [Fact]
+        public async Task WhenMarkingAsRead_SetsReadAtToUtcNow()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            var beforeTime = DateTime.UtcNow.AddSeconds(-1);
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            var afterTime = DateTime.UtcNow.AddSeconds(1);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().NotBeNull();
+            updatedNotification.ReadAt.Should().BeAfter(beforeTime);
+            updatedNotification.ReadAt.Should().BeBefore(afterTime);
+        }
+
+        [Fact]
+        public async Task WithMultipleUnreadChatNotifications_MarksAllAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification1 = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            var notification2 = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            var notification3 = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.AddRange(notification1, notification2, notification3);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareChatNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var markedAsReadCount = await context.Notifications
+                .Where(n => n.UserId == user.Id && n.ShareId == 1 && n.ReadAt != null)
+                .CountAsync();
+
+            markedAsReadCount.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task WithNoMatchingNotifications_DoesNotThrowException()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            // Act
+            var act = async () => await notificationService.MarkShareChatNotificationsAsReadAsync(999, user.Id);
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+    }
+}

--- a/BookSharingApp.Tests/Services/MarkShareNotificationsAsReadAsyncTests.cs
+++ b/BookSharingApp.Tests/Services/MarkShareNotificationsAsReadAsyncTests.cs
@@ -1,0 +1,358 @@
+using BookSharingApp.Common;
+using BookSharingApp.Services;
+using BookSharingApp.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BookSharingApp.Tests.Services
+{
+    public class MarkShareNotificationsAsReadAsyncTests : IDisposable
+    {
+        private readonly Mock<ILogger<NotificationService>> _loggerMock;
+
+        public MarkShareNotificationsAsReadAsyncTests()
+        {
+            _loggerMock = new Mock<ILogger<NotificationService>>();
+        }
+
+        public void Dispose()
+        {
+            // Cleanup if needed
+        }
+
+        [Fact]
+        public async Task WithUnreadShareStatusChangedNotification_MarksAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task WithUnreadShareDueDateChangedNotification_MarksAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareDueDateChanged,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task WithUnreadShareMessageReceivedNotification_DoesNotMarkAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithMixedNotificationTypes_OnlyMarksShareStatusAndDueDateTypes()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var statusNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var dueDateNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareDueDateChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var messageNotification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareMessageReceived,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.AddRange(statusNotification, dueDateNotification, messageNotification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedStatusNotification = await context.Notifications.FindAsync(statusNotification.Id);
+            var updatedDueDateNotification = await context.Notifications.FindAsync(dueDateNotification.Id);
+            var updatedMessageNotification = await context.Notifications.FindAsync(messageNotification.Id);
+
+            updatedStatusNotification!.ReadAt.Should().NotBeNull();
+            updatedDueDateNotification!.ReadAt.Should().NotBeNull();
+            updatedMessageNotification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithNotificationsForDifferentUser_DoesNotMarkAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user1 = TestDataBuilder.CreateUser(id: "user-1");
+            var user2 = TestDataBuilder.CreateUser(id: "user-2");
+            context.Users.AddRange(user1, user2);
+            await context.SaveChangesAsync();
+
+            var user1Notification = TestDataBuilder.CreateNotification(
+                userId: user1.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var user2Notification = TestDataBuilder.CreateNotification(
+                userId: user2.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.AddRange(user1Notification, user2Notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user1.Id);
+
+            // Assert
+            var updatedUser1Notification = await context.Notifications.FindAsync(user1Notification.Id);
+            var updatedUser2Notification = await context.Notifications.FindAsync(user2Notification.Id);
+
+            updatedUser1Notification!.ReadAt.Should().NotBeNull();
+            updatedUser2Notification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithNotificationsForDifferentShare_DoesNotMarkAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var share1Notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var share2Notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 2,
+                readAt: null
+            );
+            context.Notifications.AddRange(share1Notification, share2Notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedShare1Notification = await context.Notifications.FindAsync(share1Notification.Id);
+            var updatedShare2Notification = await context.Notifications.FindAsync(share2Notification.Id);
+
+            updatedShare1Notification!.ReadAt.Should().NotBeNull();
+            updatedShare2Notification!.ReadAt.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WithReadShareNotifications_DoesNotUpdateReadAt()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var originalReadTime = DateTime.UtcNow.AddHours(-2);
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: originalReadTime
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().Be(originalReadTime);
+        }
+
+        [Fact]
+        public async Task WhenMarkingAsRead_SetsReadAtToUtcNow()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.Add(notification);
+            await context.SaveChangesAsync();
+
+            var beforeTime = DateTime.UtcNow.AddSeconds(-1);
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            var afterTime = DateTime.UtcNow.AddSeconds(1);
+
+            // Assert
+            var updatedNotification = await context.Notifications.FindAsync(notification.Id);
+            updatedNotification.Should().NotBeNull();
+            updatedNotification!.ReadAt.Should().NotBeNull();
+            updatedNotification.ReadAt.Should().BeAfter(beforeTime);
+            updatedNotification.ReadAt.Should().BeBefore(afterTime);
+        }
+
+        [Fact]
+        public async Task WithMultipleUnreadShareNotifications_MarksAllAsRead()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var notification1 = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var notification2 = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareDueDateChanged,
+                shareId: 1,
+                readAt: null
+            );
+            var notification3 = TestDataBuilder.CreateNotification(
+                userId: user.Id,
+                notificationType: NotificationType.ShareStatusChanged,
+                shareId: 1,
+                readAt: null
+            );
+            context.Notifications.AddRange(notification1, notification2, notification3);
+            await context.SaveChangesAsync();
+
+            // Act
+            await notificationService.MarkShareNotificationsAsReadAsync(1, user.Id);
+
+            // Assert
+            var markedAsReadCount = await context.Notifications
+                .Where(n => n.UserId == user.Id && n.ShareId == 1 && n.ReadAt != null)
+                .CountAsync();
+
+            markedAsReadCount.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task WithNoMatchingNotifications_DoesNotThrowException()
+        {
+            // Arrange
+            using var context = DbContextHelper.CreateInMemoryContext();
+            var notificationService = new NotificationService(context, _loggerMock.Object);
+
+            var user = TestDataBuilder.CreateUser(id: "user-1");
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            // Act
+            var act = async () => await notificationService.MarkShareNotificationsAsReadAsync(999, user.Id);
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+    }
+}


### PR DESCRIPTION
Implements 41 granular unit tests covering all NotificationService methods:
- CreateShareNotificationAsync (11 tests): recipient determination, authorization, property validation
- GetUnreadNotificationsAsync (10 tests): filtering, ordering, eager loading
- MarkShareNotificationsAsReadAsync (10 tests): type filtering, user/share isolation
- MarkShareChatNotificationsAsReadAsync (10 tests): chat notification management

Enhanced TestDataBuilder with CreateNotification helper for consistent test data creation. All tests follow established patterns using xUnit, EF Core In-Memory, and FluentAssertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)