### PR TITLE
feat(search): group duplicate book results by book with owner list

### DIFF
--- a/Data/DatabaseSeeder.cs
+++ b/Data/DatabaseSeeder.cs
@@ -217,6 +217,7 @@ namespace BookSharingApp.Data
 
                 // John's books (user-002)
                 new UserBook { UserId = "user-002", BookId = 1, Status = UserBookStatus.Available }, // The Great Gatsby - SHARED
+                new UserBook { UserId = "user-002", BookId = 10, Status = UserBookStatus.Available }, // Last Argument of Kings - SHARED
                 new UserBook { UserId = "user-002", BookId = 9, Status = UserBookStatus.Available }, // Before They Are Hanged
                 new UserBook { UserId = "user-002", BookId = 16, Status = UserBookStatus.Available }, // Assassin's Apprentice
                 new UserBook { UserId = "user-002", BookId = 20, Status = UserBookStatus.Available }, // Jonathan Strange & Mr Norrell

--- a/Migrations/20260118022946_AddUserBookSoftDelete.cs
+++ b/Migrations/20260118022946_AddUserBookSoftDelete.cs
@@ -44,6 +44,7 @@ namespace BookSharingApp.Migrations
                     author TEXT,
                     user_book_id INTEGER,
                     owner_user_id TEXT,
+                    owner_first_name TEXT,
                     status INTEGER,
                     community_id INTEGER,
                     community_name TEXT
@@ -56,6 +57,7 @@ namespace BookSharingApp.Migrations
                         b.author,
                         ub.user_book_id,
                         ub.user_id as owner_user_id,
+                        u.first_name as owner_first_name,
                         ub.status,
                         c.community_id,
                         c.name as community_name
@@ -64,6 +66,7 @@ namespace BookSharingApp.Migrations
                         AND ub.status != 2
                         AND ub.user_id != p_user_id
                         AND ub.is_deleted = FALSE
+                    INNER JOIN ""AspNetUsers"" u ON u.""Id"" = ub.user_id
                     INNER JOIN community_user cu ON cu.user_id = ub.user_id
                     INNER JOIN community c ON c.community_id = cu.community_id AND c.active = true
                     WHERE c.community_id IN (

--- a/Models/SearchBookResult.cs
+++ b/Models/SearchBookResult.cs
@@ -19,6 +19,9 @@ namespace BookSharingApp.Models
         [Column("owner_user_id")]
         public string OwnerUserId { get; set; } = string.Empty;
 
+        [Column("owner_first_name")]
+        public string OwnerFirstName { get; set; } = string.Empty;
+
         [Column("status")]
         public int Status { get; set; }
 
@@ -26,6 +29,24 @@ namespace BookSharingApp.Models
         public int CommunityId { get; set; }
 
         [Column("community_name")]
+        public string CommunityName { get; set; } = string.Empty;
+    }
+
+    public class GroupedSearchBookResult
+    {
+        public int BookId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Author { get; set; } = string.Empty;
+        public List<BookOwnerInfo> Owners { get; set; } = new();
+    }
+
+    public class BookOwnerInfo
+    {
+        public int UserBookId { get; set; }
+        public string OwnerUserId { get; set; } = string.Empty;
+        public string OwnerFirstName { get; set; } = string.Empty;
+        public int Status { get; set; }
+        public int CommunityId { get; set; }
         public string CommunityName { get; set; } = string.Empty;
     }
 }

--- a/Services/IUserBookService.cs
+++ b/Services/IUserBookService.cs
@@ -7,7 +7,7 @@ namespace BookSharingApp.Services
     {
         // Reads
         Task<List<UserBook>> GetUserBooksAsync(string userId);
-        Task<List<SearchBookResult>> SearchAccessibleBooksAsync(string userId, string? search);
+        Task<List<GroupedSearchBookResult>> SearchAccessibleBooksAsync(string userId, string? search);
 
         // Writes
         Task<UserBook> AddUserBookAsync(int bookId, string userId);

--- a/Services/UserBookService.cs
+++ b/Services/UserBookService.cs
@@ -29,14 +29,33 @@ namespace BookSharingApp.Services
                 .ToListAsync();
         }
 
-        public async Task<List<SearchBookResult>> SearchAccessibleBooksAsync(string userId, string? search)
+        public async Task<List<GroupedSearchBookResult>> SearchAccessibleBooksAsync(string userId, string? search)
         {
-            return await _context.Database
+            var rawResults = await _context.Database
                 .SqlQueryRaw<SearchBookResult>(
                     "SELECT * FROM search_accessible_books({0}, {1})",
                     userId,
                     search ?? string.Empty)
                 .ToListAsync();
+
+            return rawResults
+                .GroupBy(r => new { r.BookId, r.Title, r.Author })
+                .Select(g => new GroupedSearchBookResult
+                {
+                    BookId = g.Key.BookId,
+                    Title = g.Key.Title,
+                    Author = g.Key.Author,
+                    Owners = g.Select(r => new BookOwnerInfo
+                    {
+                        UserBookId = r.UserBookId,
+                        OwnerUserId = r.OwnerUserId,
+                        OwnerFirstName = r.OwnerFirstName,
+                        Status = r.Status,
+                        CommunityId = r.CommunityId,
+                        CommunityName = r.CommunityName
+                    }).ToList()
+                })
+                .ToList();
         }
 
         public async Task<UserBook> AddUserBookAsync(int bookId, string userId)


### PR DESCRIPTION
## Summary
- Returns `GroupedSearchBookResult` from `SearchAccessibleBooksAsync` so multiple owners of the same book in shared communities are collapsed into a single result with a list of owners
- Added `owner_first_name` to the `search_accessible_books` SQL function (joins `AspNetUsers`) and exposed it on the result model
- Added `GroupedSearchBookResult` and `BookOwnerInfo` models to support the grouped response shape
- Added a missing seed entry for user-002 owning Book 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)