### PR TITLE
feat(auth): add DELETE /auth/account for Apple App Store compliance

### DIFF
--- a/BookSharingApp.Tests/Helpers/DbContextHelper.cs
+++ b/BookSharingApp.Tests/Helpers/DbContextHelper.cs
@@ -1,5 +1,6 @@
 using BookSharingApp.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace BookSharingApp.Tests.Helpers
 {
@@ -10,6 +11,7 @@ namespace BookSharingApp.Tests.Helpers
             // Use a unique database name for each test to ensure isolation
             var options = new DbContextOptionsBuilder<ApplicationDbContext>()
                 .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                 .Options;
 
             var context = new ApplicationDbContext(options);
@@ -24,6 +26,7 @@ namespace BookSharingApp.Tests.Helpers
         {
             var options = new DbContextOptionsBuilder<ApplicationDbContext>()
                 .UseInMemoryDatabase(databaseName: databaseName)
+                .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                 .Options;
 
             var context = new ApplicationDbContext(options);

--- a/BookSharingApp.Tests/Services/UserDeletionServiceTests.cs
+++ b/BookSharingApp.Tests/Services/UserDeletionServiceTests.cs
@@ -1,0 +1,564 @@
+using BookSharingApp.Common;
+using BookSharingApp.Models;
+using BookSharingApp.Services;
+using BookSharingApp.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BookSharingApp.Tests.Services
+{
+    public class UserDeletionServiceTests
+    {
+        public abstract class UserDeletionServiceTestBase : IDisposable
+        {
+            protected readonly Mock<IShareService> ShareServiceMock;
+            protected readonly Mock<INotificationService> NotificationServiceMock;
+            protected readonly Mock<ILogger<UserDeletionService>> LoggerMock;
+
+            protected UserDeletionServiceTestBase()
+            {
+                ShareServiceMock = new Mock<IShareService>();
+                NotificationServiceMock = new Mock<INotificationService>();
+                LoggerMock = new Mock<ILogger<UserDeletionService>>();
+
+                ShareServiceMock
+                    .Setup(s => s.HandleUserBookDeletionAsync(It.IsAny<int>(), It.IsAny<string>()))
+                    .ReturnsAsync(false);
+            }
+
+            public void Dispose() { }
+        }
+
+        public class DeleteUserAsyncTests : UserDeletionServiceTestBase
+        {
+            // ── User not found ────────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_WithNonExistentUser_ThrowsInvalidOperationException()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+
+                var act = () => service.DeleteUserAsync("nonexistent-user");
+
+                await act.Should().ThrowAsync<InvalidOperationException>()
+                    .WithMessage("User not found");
+            }
+
+            // ── PII scrub ─────────────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_ScrubsUserPIIInPlace()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1", firstName: "John", lastName: "Doe", email: "john@example.com");
+                user.PhoneNumber = "555-1234";
+                user.PasswordHash = "some-hash";
+                context.Users.Add(user);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var scrubbed = await context.Users.FindAsync("user-1");
+                scrubbed!.Email.Should().Be("deleted-user-1@deleted.invalid");
+                scrubbed.NormalizedEmail.Should().Be("DELETED-USER-1@DELETED.INVALID");
+                scrubbed.UserName.Should().Be("deleted-user-1");
+                scrubbed.NormalizedUserName.Should().Be("DELETED-USER-1");
+                scrubbed.FirstName.Should().Be("[Deleted");
+                scrubbed.LastName.Should().Be("User]");
+                scrubbed.PhoneNumber.Should().BeNull();
+                scrubbed.PasswordHash.Should().BeNull();
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_PermanentlyLocksAccount()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var scrubbed = await context.Users.FindAsync("user-1");
+                scrubbed!.LockoutEnabled.Should().BeTrue();
+                scrubbed.LockoutEnd.Should().Be(DateTimeOffset.MaxValue);
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_RotatesSecurityStamp()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var originalStamp = "original-stamp";
+                user.SecurityStamp = originalStamp;
+                context.Users.Add(user);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var scrubbed = await context.Users.FindAsync("user-1");
+                scrubbed!.SecurityStamp.Should().NotBe(originalStamp);
+                scrubbed.SecurityStamp.Should().NotBeNullOrEmpty();
+            }
+
+            // ── Refresh tokens ────────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_DeletesAllRefreshTokensForUser()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var otherUser = TestDataBuilder.CreateUser(id: "other-user");
+                context.Users.AddRange(user, otherUser);
+                await context.SaveChangesAsync();
+
+                context.RefreshTokens.AddRange(
+                    new RefreshToken { Token = "token-1", UserId = "user-1", ExpiresAt = DateTime.UtcNow.AddDays(7) },
+                    new RefreshToken { Token = "token-2", UserId = "user-1", ExpiresAt = DateTime.UtcNow.AddDays(7) },
+                    new RefreshToken { Token = "token-3", UserId = "other-user", ExpiresAt = DateTime.UtcNow.AddDays(7) }
+                );
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var remaining = await context.RefreshTokens.ToListAsync();
+                remaining.Should().HaveCount(1);
+                remaining.Single().UserId.Should().Be("other-user");
+            }
+
+            // ── Notifications ─────────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_DeletesNotificationsForUser()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var otherUser = TestDataBuilder.CreateUser(id: "other-user");
+                context.Users.AddRange(user, otherUser);
+                await context.SaveChangesAsync();
+
+                context.Notifications.AddRange(
+                    TestDataBuilder.CreateNotification(userId: "user-1", createdByUserId: "other-user"),
+                    TestDataBuilder.CreateNotification(userId: "user-1", createdByUserId: "other-user"),
+                    TestDataBuilder.CreateNotification(userId: "other-user", createdByUserId: "user-1")
+                );
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var remaining = await context.Notifications.ToListAsync();
+                remaining.Should().HaveCount(1);
+                remaining.Single().UserId.Should().Be("other-user");
+            }
+
+            // ── ShareUserStates ───────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_DeletesShareUserStatesForUser()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var otherUser = TestDataBuilder.CreateUser(id: "other-user");
+                var lender = TestDataBuilder.CreateUser(id: "lender-1");
+                context.Users.AddRange(user, otherUser, lender);
+                var book = TestDataBuilder.CreateBook();
+                context.Books.Add(book);
+                await context.SaveChangesAsync();
+
+                var userBook = TestDataBuilder.CreateUserBook(userId: "lender-1", bookId: book.Id, user: lender, book: book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                var share1 = TestDataBuilder.CreateShare(userBookId: userBook.Id, borrower: "user-1", userBook: userBook, borrowerUser: user);
+                context.Shares.Add(share1);
+                await context.SaveChangesAsync();
+
+                var share2 = TestDataBuilder.CreateShare(userBookId: userBook.Id, borrower: "other-user", userBook: userBook, borrowerUser: otherUser);
+                context.Shares.Add(share2);
+                await context.SaveChangesAsync();
+
+                context.ShareUserStates.Add(
+                    TestDataBuilder.CreateShareUserState(shareId: share1.Id, userId: "user-1", isArchived: true, share: share1, user: user));
+                await context.SaveChangesAsync();
+                context.ShareUserStates.Add(
+                    TestDataBuilder.CreateShareUserState(shareId: share2.Id, userId: "other-user", isArchived: true, share: share2, user: otherUser));
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var remaining = await context.ShareUserStates.ToListAsync();
+                remaining.Should().HaveCount(1);
+                remaining.Single().UserId.Should().Be("other-user");
+            }
+
+            // ── Chat messages ─────────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_ScrubsNonSystemChatMessageContent()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var otherUser = TestDataBuilder.CreateUser(id: "other-user");
+                context.Users.AddRange(user, otherUser);
+                var thread = TestDataBuilder.CreateChatThread();
+                context.ChatThreads.Add(thread);
+                await context.SaveChangesAsync();
+
+                context.ChatMessages.AddRange(
+                    TestDataBuilder.CreateChatMessage(threadId: thread.Id, senderId: "user-1", content: "Hello there"),
+                    TestDataBuilder.CreateChatMessage(threadId: thread.Id, senderId: "user-1", content: "Another message"),
+                    TestDataBuilder.CreateChatMessage(threadId: thread.Id, senderId: "other-user", content: "Other user message")
+                );
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var userMessages = await context.ChatMessages
+                    .Where(m => m.SenderId == "user-1")
+                    .ToListAsync();
+                userMessages.Should().AllSatisfy(m => m.Content.Should().Be("[deleted]"));
+
+                var otherMessage = await context.ChatMessages
+                    .FirstAsync(m => m.SenderId == "other-user");
+                otherMessage.Content.Should().Be("Other user message");
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_DoesNotScrubSystemMessages()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                var thread = TestDataBuilder.CreateChatThread();
+                context.ChatThreads.Add(thread);
+                await context.SaveChangesAsync();
+
+                var systemMessage = TestDataBuilder.CreateChatMessage(
+                    threadId: thread.Id,
+                    senderId: "user-1",
+                    content: "Status changed to Ready",
+                    isSystemMessage: true);
+                context.ChatMessages.Add(systemMessage);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var msg = await context.ChatMessages.FindAsync(systemMessage.Id);
+                msg!.Content.Should().Be("Status changed to Ready");
+            }
+
+            // ── Borrower-side share handling ──────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_WithRequestedBorrowerShare_DeclinesShare()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var lender = TestDataBuilder.CreateUser(id: "lender-1");
+                context.Users.AddRange(user, lender);
+                var book = TestDataBuilder.CreateBook();
+                context.Books.Add(book);
+                await context.SaveChangesAsync();
+
+                var userBook = TestDataBuilder.CreateUserBook(userId: "lender-1", bookId: book.Id, user: lender, book: book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                var share = TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id,
+                    borrower: "user-1",
+                    status: ShareStatus.Requested,
+                    userBook: userBook,
+                    borrowerUser: user);
+                context.Shares.Add(share);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var updatedShare = await context.Shares.FindAsync(share.Id);
+                updatedShare!.Status.Should().Be(ShareStatus.Declined);
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_WithRequestedBorrowerShare_NotifiesLender()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var lender = TestDataBuilder.CreateUser(id: "lender-1");
+                context.Users.AddRange(user, lender);
+                var book = TestDataBuilder.CreateBook(title: "Dune");
+                context.Books.Add(book);
+                await context.SaveChangesAsync();
+
+                var userBook = TestDataBuilder.CreateUserBook(userId: "lender-1", bookId: book.Id, user: lender, book: book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                var share = TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id,
+                    borrower: "user-1",
+                    status: ShareStatus.Requested,
+                    userBook: userBook,
+                    borrowerUser: user);
+                context.Shares.Add(share);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                NotificationServiceMock.Verify(n => n.CreateShareNotificationAsync(
+                    share.Id,
+                    NotificationType.ShareStatusChanged,
+                    It.Is<string>(msg => msg.Contains("Dune")),
+                    "user-1"),
+                    Times.Once);
+            }
+
+            [Theory]
+            [InlineData(ShareStatus.Ready)]
+            [InlineData(ShareStatus.PickedUp)]
+            [InlineData(ShareStatus.Returned)]
+            public async Task DeleteUserAsync_WithActiveShareAsBorrower_DoesNotDeclineShare(ShareStatus activeStatus)
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var lender = TestDataBuilder.CreateUser(id: "lender-1");
+                context.Users.AddRange(user, lender);
+                var book = TestDataBuilder.CreateBook();
+                context.Books.Add(book);
+                await context.SaveChangesAsync();
+
+                var userBook = TestDataBuilder.CreateUserBook(userId: "lender-1", bookId: book.Id, user: lender, book: book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                var share = TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id,
+                    borrower: "user-1",
+                    status: activeStatus,
+                    userBook: userBook,
+                    borrowerUser: user);
+                context.Shares.Add(share);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var unchanged = await context.Shares.FindAsync(share.Id);
+                unchanged!.Status.Should().Be(activeStatus);
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_WithDisputedRequestedShare_DoesNotDeclineShare()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var lender = TestDataBuilder.CreateUser(id: "lender-1");
+                context.Users.AddRange(user, lender);
+                var book = TestDataBuilder.CreateBook();
+                context.Books.Add(book);
+                await context.SaveChangesAsync();
+
+                var userBook = TestDataBuilder.CreateUserBook(userId: "lender-1", bookId: book.Id, user: lender, book: book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                var share = TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id,
+                    borrower: "user-1",
+                    status: ShareStatus.Requested,
+                    isDisputed: true,
+                    userBook: userBook,
+                    borrowerUser: user);
+                context.Shares.Add(share);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var unchanged = await context.Shares.FindAsync(share.Id);
+                unchanged!.Status.Should().Be(ShareStatus.Requested);
+            }
+
+            // ── Lender-side user book handling ────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_WithUserBooks_SoftDeletesAllUserBooks()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                var book1 = TestDataBuilder.CreateBook(title: "Book One");
+                var book2 = TestDataBuilder.CreateBook(title: "Book Two");
+                context.Books.AddRange(book1, book2);
+                await context.SaveChangesAsync();
+
+                var userBook1 = TestDataBuilder.CreateUserBook(userId: "user-1", bookId: book1.Id, user: user, book: book1);
+                var userBook2 = TestDataBuilder.CreateUserBook(userId: "user-1", bookId: book2.Id, user: user, book: book2);
+                context.UserBooks.AddRange(userBook1, userBook2);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var userBooks = await context.UserBooks.Where(ub => ub.UserId == "user-1").ToListAsync();
+                userBooks.Should().AllSatisfy(ub =>
+                {
+                    ub.IsDeleted.Should().BeTrue();
+                    ub.DeletedAt.Should().NotBeNull();
+                });
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_WithUserBooks_CallsHandleUserBookDeletionForEach()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                var book1 = TestDataBuilder.CreateBook();
+                var book2 = TestDataBuilder.CreateBook();
+                context.Books.AddRange(book1, book2);
+                await context.SaveChangesAsync();
+
+                var userBook1 = TestDataBuilder.CreateUserBook(userId: "user-1", bookId: book1.Id, user: user, book: book1);
+                var userBook2 = TestDataBuilder.CreateUserBook(userId: "user-1", bookId: book2.Id, user: user, book: book2);
+                context.UserBooks.AddRange(userBook1, userBook2);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                ShareServiceMock.Verify(s => s.HandleUserBookDeletionAsync(It.IsAny<int>(), "user-1"), Times.Exactly(2));
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_WithAlreadyDeletedUserBook_SkipsIt()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                var book = TestDataBuilder.CreateBook();
+                context.Books.Add(book);
+                await context.SaveChangesAsync();
+
+                var alreadyDeleted = TestDataBuilder.CreateUserBook(userId: "user-1", bookId: book.Id, user: user, book: book, isDeleted: true, deletedAt: DateTime.UtcNow.AddDays(-1));
+                context.UserBooks.Add(alreadyDeleted);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                ShareServiceMock.Verify(s => s.HandleUserBookDeletionAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+            }
+
+            // ── Community handling ────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_RemovesUserFromAllCommunities()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var otherUser = TestDataBuilder.CreateUser(id: "other-user");
+                context.Users.AddRange(user, otherUser);
+                var community1 = TestDataBuilder.CreateCommunity(createdBy: "other-user");
+                var community2 = TestDataBuilder.CreateCommunity(createdBy: "other-user");
+                context.Communities.AddRange(community1, community2);
+                await context.SaveChangesAsync();
+
+                context.CommunityUsers.AddRange(
+                    TestDataBuilder.CreateCommunityUser(community1.Id, "user-1"),
+                    TestDataBuilder.CreateCommunityUser(community1.Id, "other-user"),
+                    TestDataBuilder.CreateCommunityUser(community2.Id, "user-1"),
+                    TestDataBuilder.CreateCommunityUser(community2.Id, "other-user")
+                );
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var userMemberships = await context.CommunityUsers
+                    .Where(cu => cu.UserId == "user-1")
+                    .ToListAsync();
+                userMemberships.Should().BeEmpty();
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_WhenLastMemberOfCommunity_DeletesCommunity()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                var community = TestDataBuilder.CreateCommunity(createdBy: "user-1");
+                context.Communities.Add(community);
+                await context.SaveChangesAsync();
+
+                context.CommunityUsers.Add(TestDataBuilder.CreateCommunityUser(community.Id, "user-1"));
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var deletedCommunity = await context.Communities.FindAsync(community.Id);
+                deletedCommunity.Should().BeNull();
+            }
+
+            [Fact]
+            public async Task DeleteUserAsync_WhenNotLastMemberOfCommunity_KeepsCommunity()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var otherUser = TestDataBuilder.CreateUser(id: "other-user");
+                context.Users.AddRange(user, otherUser);
+                var community = TestDataBuilder.CreateCommunity(createdBy: "other-user");
+                context.Communities.Add(community);
+                await context.SaveChangesAsync();
+
+                context.CommunityUsers.AddRange(
+                    TestDataBuilder.CreateCommunityUser(community.Id, "user-1"),
+                    TestDataBuilder.CreateCommunityUser(community.Id, "other-user")
+                );
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                await service.DeleteUserAsync("user-1");
+
+                var surviving = await context.Communities.FindAsync(community.Id);
+                surviving.Should().NotBeNull();
+
+                var remainingMembers = await context.CommunityUsers
+                    .Where(cu => cu.CommunityId == community.Id)
+                    .ToListAsync();
+                remainingMembers.Should().HaveCount(1);
+                remainingMembers.Single().UserId.Should().Be("other-user");
+            }
+
+            // ── Edge cases ────────────────────────────────────────────────────
+
+            [Fact]
+            public async Task DeleteUserAsync_WithNoAssociatedData_CompletesSuccessfully()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                await context.SaveChangesAsync();
+
+                var service = new UserDeletionService(context, ShareServiceMock.Object, NotificationServiceMock.Object, LoggerMock.Object);
+                var act = () => service.DeleteUserAsync("user-1");
+
+                await act.Should().NotThrowAsync();
+            }
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ BookSharingWebAPI/
 - Authentication via ASP.NET Core Identity with JWT tokens
 - Can join multiple communities
 - Managed by ASP.NET Core Identity tables
+- **Account deletion (tombstone pattern):** `DELETE /auth/account` scrubs all PII in-place rather than deleting the row, preserving FK integrity across shares, chat messages, and notifications. The `aspnetusers` row is kept with name set to "[Deleted User]", email/password nulled, and account permanently locked. Chat message content is replaced with "[deleted]". No schema migration required.
 
 ### Book
 - Basic book information: id, title, author, thumbnailUrl
@@ -299,6 +300,7 @@ The core entity representing a book-sharing relationship between lender and borr
 - `POST /auth/register` - Create account
 - `POST /auth/login` - Authenticate user
 - `POST /auth/refresh` - Refresh access token
+- `DELETE /auth/account` - Permanently delete the authenticated user's account (Apple App Store compliant)
 
 ### Books (`/books`)
 - `GET /books` - List all books

--- a/Endpoints/AuthEndpoints.cs
+++ b/Endpoints/AuthEndpoints.cs
@@ -2,10 +2,12 @@ using BookSharingApp.Common;
 using BookSharingApp.Data;
 using BookSharingApp.Models;
 using BookSharingApp.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 
 namespace BookSharingApp.Endpoints
 {
@@ -35,6 +37,24 @@ namespace BookSharingApp.Endpoints
                 .WithMetadata(new RateLimitAttribute(RateLimitNames.AuthRefresh, RateLimitScope.Ip))
                 .Produces<AuthResponseDto>()
                 .ProducesValidationProblem();
+
+            auth.MapDelete("/account", DeleteAccountAsync)
+                .WithName("DeleteAccount")
+                .WithSummary("Permanently delete the authenticated user's account and all associated personal data")
+                .RequireAuthorization()
+                .Produces(StatusCodes.Status204NoContent);
+        }
+
+        private static async Task<IResult> DeleteAccountAsync(
+            HttpContext httpContext,
+            IUserDeletionService userDeletionService)
+        {
+            var userId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            await userDeletionService.DeleteUserAsync(userId);
+            return Results.NoContent();
         }
 
         private static async Task<IResult> RegisterAsync(

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,23 @@
+# Privacy Policy
+
+_Last updated: 2026-03-29_
+
+## Account Deletion
+
+Users may permanently delete their account at any time via the app settings or by calling `DELETE /auth/account`. Upon deletion:
+
+- All personal information (name, email, password) is immediately and permanently removed from our systems.
+- Active login sessions and refresh tokens are revoked.
+- Personal notifications are deleted.
+
+**Retained anonymized data:** To preserve the continuity of experience for other users who were party to a book-lending transaction or chat conversation with the deleted user, we retain anonymized transaction records and chat thread structure. Specifically:
+
+- Share (lending transaction) records are kept but display the deleted user as "[Deleted User]".
+- Chat messages sent by the deleted user have their content replaced with "[deleted]"; the message structure is retained so conversation history for other participants remains coherent.
+- Community records created by the deleted user remain intact for remaining members.
+
+This retention is limited to data that benefits other parties and contains no personally identifiable information. It is consistent with Apple App Store Guideline 5.1.1(v) and applicable privacy regulations' carve-outs for operational necessity.
+
+## Contact
+
+For privacy-related inquiries, contact: landonpvance@gmail.com

--- a/Program.cs
+++ b/Program.cs
@@ -70,18 +70,9 @@ builder.Services.AddAuthentication(options =>
         ValidateAudience = false,
         ClockSkew = TimeSpan.Zero
     };
-});
-
-builder.Services.AddAuthorization();
-
-// Configure SignalR with JWT authentication
-builder.Services.AddSignalR();
-
-// Configure JWT for SignalR
-builder.Services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
-{
     options.Events = new JwtBearerEvents
     {
+        // Allow SignalR to pass the JWT via query string
         OnMessageReceived = context =>
         {
             var accessToken = context.Request.Query["access_token"];
@@ -91,9 +82,31 @@ builder.Services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationSch
                 context.Token = accessToken;
             }
             return Task.CompletedTask;
+        },
+        // Reject tokens for deleted/locked-out accounts immediately
+        OnTokenValidated = async context =>
+        {
+            var userId = context.Principal?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+            if (userId is null)
+            {
+                context.Fail("Missing user identifier");
+                return;
+            }
+
+            var userManager = context.HttpContext.RequestServices.GetRequiredService<UserManager<User>>();
+            var user = await userManager.FindByIdAsync(userId);
+            if (user is null || user.LockoutEnd == DateTimeOffset.MaxValue)
+            {
+                context.Fail("Account has been deleted");
+            }
         }
     };
 });
+
+builder.Services.AddAuthorization();
+
+// Configure SignalR with JWT authentication
+builder.Services.AddSignalR();
 
 // Register custom services
 builder.Services.AddScoped<ITokenService, TokenService>();
@@ -101,6 +114,7 @@ builder.Services.AddScoped<IChatService, ChatService>();
 builder.Services.AddScoped<IShareService, ShareService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IUserBookService, UserBookService>();
+builder.Services.AddScoped<IUserDeletionService, UserDeletionService>();
 builder.Services.AddSingleton<IRateLimitService, RateLimitService>();
 builder.Services.AddSingleton<IRateLimiter>(provider =>
 {

--- a/Services/IUserDeletionService.cs
+++ b/Services/IUserDeletionService.cs
@@ -1,0 +1,11 @@
+namespace BookSharingApp.Services
+{
+    public interface IUserDeletionService
+    {
+        /// <summary>
+        /// Permanently deletes a user account by scrubbing all PII in-place (tombstone pattern).
+        /// Retains anonymized relational data for the other parties to shares and chat threads.
+        /// </summary>
+        Task DeleteUserAsync(string userId);
+    }
+}

--- a/Services/UserDeletionService.cs
+++ b/Services/UserDeletionService.cs
@@ -1,0 +1,161 @@
+using BookSharingApp.Common;
+using BookSharingApp.Data;
+using BookSharingApp.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookSharingApp.Services
+{
+    public class UserDeletionService : IUserDeletionService
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IShareService _shareService;
+        private readonly INotificationService _notificationService;
+        private readonly ILogger<UserDeletionService> _logger;
+
+        public UserDeletionService(
+            ApplicationDbContext context,
+            IShareService shareService,
+            INotificationService notificationService,
+            ILogger<UserDeletionService> logger)
+        {
+            _context = context;
+            _shareService = shareService;
+            _notificationService = notificationService;
+            _logger = logger;
+        }
+
+        public async Task DeleteUserAsync(string userId)
+        {
+            var user = await _context.Users.FindAsync(userId);
+            if (user is null)
+                throw new InvalidOperationException("User not found");
+
+            _logger.LogInformation("Starting account deletion for user {UserId}", userId);
+
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+            try
+            {
+                // Steps 1-4: Hard deletes and chat scrub — no interdependencies, batched into one save
+                var refreshTokens = await _context.RefreshTokens
+                    .Where(rt => rt.UserId == userId)
+                    .ToListAsync();
+                _context.RefreshTokens.RemoveRange(refreshTokens);
+                _logger.LogDebug("Queued deletion of {Count} refresh tokens for user {UserId}", refreshTokens.Count, userId);
+
+                var notifications = await _context.Notifications
+                    .Where(n => n.UserId == userId)
+                    .ToListAsync();
+                _context.Notifications.RemoveRange(notifications);
+                _logger.LogDebug("Queued deletion of {Count} notifications for user {UserId}", notifications.Count, userId);
+
+                var shareUserStates = await _context.ShareUserStates
+                    .Where(sus => sus.UserId == userId)
+                    .ToListAsync();
+                _context.ShareUserStates.RemoveRange(shareUserStates);
+                _logger.LogDebug("Queued deletion of {Count} share user states for user {UserId}", shareUserStates.Count, userId);
+
+                var chatMessages = await _context.ChatMessages
+                    .Where(m => m.SenderId == userId && !m.IsSystemMessage)
+                    .ToListAsync();
+                foreach (var message in chatMessages)
+                    message.Content = "[deleted]";
+                _logger.LogDebug("Queued scrub of {Count} chat messages for user {UserId}", chatMessages.Count, userId);
+
+                await _context.SaveChangesAsync();
+
+                // Step 5: Auto-decline requested shares where this user is the borrower, notify lenders
+                var requestedBorrowerShares = await _context.Shares
+                    .Include(s => s.UserBook)
+                        .ThenInclude(ub => ub.Book)
+                    .Where(s => s.Borrower == userId &&
+                                s.Status == ShareStatus.Requested &&
+                                !s.IsDisputed)
+                    .ToListAsync();
+
+                foreach (var share in requestedBorrowerShares)
+                    share.Status = ShareStatus.Declined;
+
+                await _context.SaveChangesAsync();
+                _logger.LogDebug("Auto-declined {Count} requested shares for user {UserId}", requestedBorrowerShares.Count, userId);
+
+                foreach (var share in requestedBorrowerShares)
+                {
+                    try
+                    {
+                        var bookTitle = share.UserBook?.Book?.Title ?? "a book";
+                        await _notificationService.CreateShareNotificationAsync(
+                            share.Id,
+                            NotificationType.ShareStatusChanged,
+                            $"The borrower's request for '{bookTitle}' was cancelled because they deleted their account",
+                            userId);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to notify lender of declined share {ShareId} during account deletion for user {UserId}", share.Id, userId);
+                    }
+                }
+
+                // Step 6: Handle lender-side share cleanup for each of the user's books, then soft-delete them
+                // Note: HandleUserBookDeletionAsync manages shares (auto-decline requested, notify active borrowers)
+                // but does NOT soft-delete the UserBook itself — that's done here
+                var userBooks = await _context.UserBooks
+                    .Where(ub => ub.UserId == userId && !ub.IsDeleted)
+                    .ToListAsync();
+
+                foreach (var userBook in userBooks)
+                {
+                    await _shareService.HandleUserBookDeletionAsync(userBook.Id, userId);
+                    userBook.IsDeleted = true;
+                    userBook.DeletedAt = DateTime.UtcNow;
+                }
+                await _context.SaveChangesAsync();
+                _logger.LogDebug("Soft-deleted {Count} user books for user {UserId}", userBooks.Count, userId);
+
+                // Step 7: Leave all communities (delete community if last member)
+                var communityMemberships = await _context.CommunityUsers
+                    .Where(cu => cu.UserId == userId)
+                    .ToListAsync();
+
+                foreach (var membership in communityMemberships)
+                {
+                    var memberCount = await _context.CommunityUsers
+                        .CountAsync(cu => cu.CommunityId == membership.CommunityId);
+
+                    _context.CommunityUsers.Remove(membership);
+
+                    if (memberCount == 1)
+                    {
+                        var community = await _context.Communities.FindAsync(membership.CommunityId);
+                        if (community is not null)
+                            _context.Communities.Remove(community);
+                    }
+                }
+                await _context.SaveChangesAsync();
+                _logger.LogDebug("Removed user {UserId} from {Count} communities", userId, communityMemberships.Count);
+
+                // Step 8: Scrub PII from the aspnetusers row in-place (tombstone)
+                user.Email = $"deleted-{userId}@deleted.invalid";
+                user.NormalizedEmail = $"DELETED-{userId.ToUpper()}@DELETED.INVALID";
+                user.UserName = $"deleted-{userId}";
+                user.NormalizedUserName = $"DELETED-{userId.ToUpper()}";
+                user.FirstName = "[Deleted";
+                user.LastName = "User]";
+                user.PhoneNumber = null;
+                user.PasswordHash = null;
+                user.SecurityStamp = Guid.NewGuid().ToString();
+                user.LockoutEnabled = true;
+                user.LockoutEnd = DateTimeOffset.MaxValue;
+                await _context.SaveChangesAsync();
+
+                await transaction.CommitAsync();
+
+                _logger.LogInformation("Successfully deleted account for user {UserId}", userId);
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DELETE /auth/account` endpoint that permanently deletes the calling user's account using a tombstone pattern (PII scrubbed in-place, FK integrity preserved)
- Fixes JWT invalidation gap: `OnTokenValidated` now rejects tokens for locked-out accounts immediately rather than waiting for 24h expiry
- Adds `PRIVACY_POLICY.md` disclosing anonymized data retention policy

## What gets deleted
- Refresh tokens, notifications, share user states — hard deleted
- Chat messages — content scrubbed to `"[deleted]"`
- User books — soft deleted; active lender-side shares handled via existing `HandleUserBookDeletionAsync`
- Pending borrower share requests — auto-declined with lender notification
- Community memberships — removed; empty communities deleted

## What gets retained (anonymized)
- Share rows, chat thread structure, community rows — FK references remain valid, name displays as `"[Deleted User]"`

## Test plan
- 22 new unit tests (`UserDeletionServiceTests`)
- Full functional test run against Docker confirmed all scenarios pass including JWT invalidation

Closes #173
Related mobile issue: landonvance1/book-share-mobile-app#118

🤖 Generated with [Claude Code](https://claude.com/claude-code)