### PR TITLE
feat(admin): add interactive CLI for viewing chat message reports

### DIFF
--- a/BookSharingApp.Cli/BookSharingApp.Cli.csproj
+++ b/BookSharingApp.Cli/BookSharingApp.Cli.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BookSharingApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BookSharingApp.Cli/Commands/ReportCommands.cs
+++ b/BookSharingApp.Cli/Commands/ReportCommands.cs
@@ -1,0 +1,171 @@
+using BookSharingApp.Cli.Formatting;
+using BookSharingApp.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookSharingApp.Cli.Commands;
+
+public static class ReportCommands
+{
+    private const int DefaultLimit = 50;
+
+    private static string FormatName(string firstName, string lastName)
+        => $"{firstName} {lastName}".Trim();
+
+    public static async Task ListAsync(ApplicationDbContext db, string? userFilter)
+    {
+        var query = db.ChatMessageReports
+            .AsNoTracking()
+            .OrderByDescending(r => r.CreatedAt)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(userFilter))
+        {
+            var filter = userFilter.ToLower();
+            query = query.Where(r =>
+                (r.ReportedUser.FirstName + " " + r.ReportedUser.LastName).ToLower().Contains(filter));
+        }
+
+        var reports = await query
+            .Take(DefaultLimit)
+            .Select(r => new
+            {
+                r.Id,
+                r.CreatedAt,
+                r.Category,
+                ReportedUser = r.ReportedUser.FirstName + " " + r.ReportedUser.LastName,
+                Reporter = r.Reporter.FirstName + " " + r.Reporter.LastName,
+                Preview = r.ReportedContent.Length > 50
+                    ? r.ReportedContent.Substring(0, 50) + "..."
+                    : r.ReportedContent
+            }).ToListAsync();
+
+        if (reports.Count == 0)
+        {
+            Console.WriteLine("No reports found.");
+            return;
+        }
+
+        var headers = new[] { "ID", "Created", "Category", "Reported User", "Reporter", "Message Preview" };
+        var rows = reports.Select(r => new[]
+        {
+            r.Id.ToString(),
+            r.CreatedAt.ToString("yyyy-MM-dd HH:mm"),
+            r.Category.ToString(),
+            r.ReportedUser.Trim(),
+            r.Reporter.Trim(),
+            r.Preview
+        }).ToList();
+
+        TableFormatter.Print(headers, rows, "report");
+    }
+
+    public static async Task ViewAsync(ApplicationDbContext db, int reportId)
+    {
+        var report = await db.ChatMessageReports
+            .AsNoTracking()
+            .Include(r => r.Reporter)
+            .Include(r => r.ReportedUser)
+            .Include(r => r.Message)
+                .ThenInclude(m => m.Thread)
+                    .ThenInclude(t => t.ShareChatThread)
+                        .ThenInclude(sct => sct!.Share)
+                            .ThenInclude(s => s.UserBook)
+                                .ThenInclude(ub => ub.Book)
+            .Include(r => r.Message)
+                .ThenInclude(m => m.Thread)
+                    .ThenInclude(t => t.ShareChatThread)
+                        .ThenInclude(sct => sct!.Share)
+                            .ThenInclude(s => s.UserBook)
+                                .ThenInclude(ub => ub.User)
+            .Include(r => r.Message)
+                .ThenInclude(m => m.Thread)
+                    .ThenInclude(t => t.ShareChatThread)
+                        .ThenInclude(sct => sct!.Share)
+                            .ThenInclude(s => s.BorrowerUser)
+            .AsSplitQuery()
+            .FirstOrDefaultAsync(r => r.Id == reportId);
+
+        if (report is null)
+        {
+            Console.WriteLine($"Report #{reportId} not found.");
+            return;
+        }
+
+        Console.WriteLine($"Report #{report.Id}");
+        Console.WriteLine(new string('─', 40));
+        Console.WriteLine($"  Created:        {report.CreatedAt:yyyy-MM-dd HH:mm:ss} UTC");
+        Console.WriteLine($"  Category:       {report.Category}");
+        Console.WriteLine($"  Reported User:  {FormatName(report.ReportedUser.FirstName, report.ReportedUser.LastName)}");
+        Console.WriteLine($"  Reporter:       {FormatName(report.Reporter.FirstName, report.Reporter.LastName)}");
+        Console.WriteLine();
+        Console.WriteLine("Message Content:");
+        Console.WriteLine($"  {report.ReportedContent}");
+        Console.WriteLine();
+        Console.WriteLine("Reporter Notes:");
+        Console.WriteLine($"  {report.Notes ?? "(none)"}");
+
+        var share = report.Message.Thread.ShareChatThread?.Share;
+        if (share is not null)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Share Context:");
+            Console.WriteLine($"  Share ID:       {share.Id}");
+            Console.WriteLine($"  Book Title:     {share.UserBook.Book.Title}");
+            Console.WriteLine($"  Lender:         {FormatName(share.UserBook.User.FirstName, share.UserBook.User.LastName)}");
+            Console.WriteLine($"  Borrower:       {FormatName(share.BorrowerUser.FirstName, share.BorrowerUser.LastName)}");
+            Console.WriteLine($"  Share Status:   {share.Status}");
+        }
+        else
+        {
+            Console.WriteLine();
+            Console.WriteLine("Share Context:");
+            Console.WriteLine("  (not available)");
+        }
+    }
+
+    public static async Task StatsAsync(ApplicationDbContext db)
+    {
+        var total = await db.ChatMessageReports.AsNoTracking().CountAsync();
+
+        if (total == 0)
+        {
+            Console.WriteLine("No reports found.");
+            return;
+        }
+
+        var byCategory = await db.ChatMessageReports.AsNoTracking()
+            .GroupBy(r => r.Category)
+            .Select(g => new { Category = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ToListAsync();
+
+        var topUsers = await db.ChatMessageReports.AsNoTracking()
+            .GroupBy(r => r.ReportedUserId)
+            .Select(g => new { UserId = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .Take(10)
+            .ToListAsync();
+
+        var userIds = topUsers.Select(x => x.UserId).ToList();
+        var users = await db.Users
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => $"{u.FirstName} {u.LastName}".Trim());
+
+        Console.WriteLine("Report Statistics");
+        Console.WriteLine(new string('─', 40));
+        Console.WriteLine($"  Total Reports: {total}");
+        Console.WriteLine();
+
+        Console.WriteLine("By Category:");
+        foreach (var cat in byCategory)
+            Console.WriteLine($"  {cat.Category,-25} {cat.Count}");
+        Console.WriteLine();
+
+        Console.WriteLine("Top Reported Users:");
+        foreach (var user in topUsers)
+        {
+            var name = users.GetValueOrDefault(user.UserId, user.UserId);
+            Console.WriteLine($"  {name,-25} {user.Count} report(s)");
+        }
+    }
+}

--- a/BookSharingApp.Cli/Formatting/TableFormatter.cs
+++ b/BookSharingApp.Cli/Formatting/TableFormatter.cs
@@ -1,0 +1,39 @@
+namespace BookSharingApp.Cli.Formatting;
+
+public static class TableFormatter
+{
+    public static void Print(string[] headers, List<string[]> rows, string itemLabel = "item")
+    {
+        var columnCount = headers.Length;
+        var widths = new int[columnCount];
+
+        for (var i = 0; i < columnCount; i++)
+            widths[i] = headers[i].Length;
+
+        foreach (var row in rows)
+        {
+            for (var i = 0; i < columnCount && i < row.Length; i++)
+            {
+                if (row[i].Length > widths[i])
+                    widths[i] = row[i].Length;
+            }
+        }
+
+        var format = string.Join("  ", widths.Select((w, i) =>
+            i == columnCount - 1 ? $"{{{i}}}" : $"{{{i},-{w}}}"));
+
+        Console.WriteLine(string.Format(format, headers));
+        Console.WriteLine(new string('─', widths.Sum() + (columnCount - 1) * 2));
+
+        foreach (var row in rows)
+        {
+            var padded = new string[columnCount];
+            for (var i = 0; i < columnCount; i++)
+                padded[i] = i < row.Length ? row[i] : "";
+            Console.WriteLine(string.Format(format, padded));
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"{rows.Count} {itemLabel}(s)");
+    }
+}

--- a/BookSharingApp.Cli/Program.cs
+++ b/BookSharingApp.Cli/Program.cs
@@ -1,0 +1,188 @@
+using BookSharingApp.Cli.Commands;
+using BookSharingApp.Data;
+using Microsoft.EntityFrameworkCore;
+
+// Resolve connection string from args or environment
+var connectionString = ResolveConnectionString(args);
+await using var db = CreateDbContext(connectionString);
+
+// If commands were passed (after stripping --connection-string), run one-shot
+var commandArgs = StripConnectionStringArgs(args);
+if (commandArgs.Length > 0)
+{
+    return await RunCommandAsync(db, commandArgs);
+}
+
+// Interactive REPL mode
+Console.WriteLine("BookSharing Admin CLI");
+Console.WriteLine("Type 'help' for available commands, 'exit' to quit.");
+Console.WriteLine();
+
+while (true)
+{
+    Console.Write(">> ");
+    var line = Console.ReadLine();
+
+    if (line is null) // EOF / Ctrl+D
+        break;
+
+    var input = line.Trim();
+    if (input.Length == 0)
+        continue;
+
+    if (input is "exit" or "quit")
+        break;
+
+    if (input == "help")
+    {
+        PrintHelp();
+        continue;
+    }
+
+    var inputArgs = SplitArgs(input);
+    var result = await RunCommandAsync(db, inputArgs);
+    if (result != 0)
+        Console.WriteLine($"Command failed (exit code {result}).");
+
+    Console.WriteLine();
+}
+
+return 0;
+
+// --- Helpers ---
+
+static async Task<int> RunCommandAsync(ApplicationDbContext db, string[] args)
+{
+    if (args.Length == 0)
+        return 1;
+
+    var baseCommand = args.Length >= 2 ? $"{args[0]} {args[1]}" : args[0];
+
+    try
+    {
+        switch (baseCommand)
+        {
+            case "reports list":
+                var userFilter = GetOptionValue(args, "--user");
+                await ReportCommands.ListAsync(db, userFilter);
+                return 0;
+
+            case "reports view" when GetPositionalArg(args, 2) is { } idStr && int.TryParse(idStr, out var id):
+                await ReportCommands.ViewAsync(db, id);
+                return 0;
+
+            case "reports view":
+                Console.Error.WriteLine("Usage: reports view <id>");
+                return 1;
+
+            case "reports stats":
+                await ReportCommands.StatsAsync(db);
+                return 0;
+
+            default:
+                Console.Error.WriteLine($"Unknown command: {baseCommand}");
+                Console.Error.WriteLine("Type 'help' for available commands.");
+                return 1;
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Error: {ex.Message}");
+        return 1;
+    }
+}
+
+static void PrintHelp()
+{
+    Console.WriteLine("Available commands:");
+    Console.WriteLine("  reports list [--user <name>]  List all reports (newest first)");
+    Console.WriteLine("  reports view <id>             View full details of a report");
+    Console.WriteLine("  reports stats                 Show report statistics");
+    Console.WriteLine("  help                          Show this help message");
+    Console.WriteLine("  exit                          Exit the CLI");
+}
+
+static string ResolveConnectionString(string[] args)
+{
+    var connStr = GetOptionValue(args, "--connection-string");
+    connStr ??= Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection");
+
+    if (string.IsNullOrWhiteSpace(connStr))
+    {
+        Console.Error.WriteLine("Error: No connection string provided.");
+        Console.Error.WriteLine("Use --connection-string or set the ConnectionStrings__DefaultConnection environment variable.");
+        Environment.Exit(1);
+        return null!;
+    }
+
+    return connStr;
+}
+
+static ApplicationDbContext CreateDbContext(string connectionString)
+{
+    var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+        .UseNpgsql(connectionString)
+        .Options;
+
+    return new ApplicationDbContext(options);
+}
+
+static string? GetOptionValue(string[] args, string optionName)
+{
+    for (var i = 0; i < args.Length - 1; i++)
+    {
+        if (args[i] == optionName)
+            return args[i + 1];
+    }
+    return null;
+}
+
+static string? GetPositionalArg(string[] args, int index)
+    => index < args.Length ? args[index] : null;
+
+static string[] StripConnectionStringArgs(string[] args)
+{
+    var result = new List<string>();
+    for (var i = 0; i < args.Length; i++)
+    {
+        if (args[i] == "--connection-string" && i + 1 < args.Length)
+        {
+            i++; // skip value too
+            continue;
+        }
+        result.Add(args[i]);
+    }
+    return result.ToArray();
+}
+
+static string[] SplitArgs(string input)
+{
+    var args = new List<string>();
+    var inQuotes = false;
+    var current = new System.Text.StringBuilder();
+
+    foreach (var c in input)
+    {
+        if (c == '"')
+        {
+            inQuotes = !inQuotes;
+        }
+        else if (c == ' ' && !inQuotes)
+        {
+            if (current.Length > 0)
+            {
+                args.Add(current.ToString());
+                current.Clear();
+            }
+        }
+        else
+        {
+            current.Append(c);
+        }
+    }
+
+    if (current.Length > 0)
+        args.Add(current.ToString());
+
+    return args.ToArray();
+}

--- a/BookSharingApp.csproj
+++ b/BookSharingApp.csproj
@@ -31,12 +31,16 @@
   <ItemGroup>
     <Compile Remove="BookSharingApp.Tests/**" />
     <Compile Remove="BookSharingApp.IntegrationTests/**" />
+    <Compile Remove="BookSharingApp.Cli/**" />
     <Content Remove="BookSharingApp.Tests/**" />
     <Content Remove="BookSharingApp.IntegrationTests/**" />
+    <Content Remove="BookSharingApp.Cli/**" />
     <None Remove="BookSharingApp.Tests/**" />
     <None Remove="BookSharingApp.IntegrationTests/**" />
+    <None Remove="BookSharingApp.Cli/**" />
     <EmbeddedResource Remove="BookSharingApp.Tests/**" />
     <EmbeddedResource Remove="BookSharingApp.IntegrationTests/**" />
+    <EmbeddedResource Remove="BookSharingApp.Cli/**" />
   </ItemGroup>
 
 </Project>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,9 @@ Replace `YOUR_LOCAL_PASSWORD` with your local PostgreSQL password and `YOUR_JWT_
 ### Project Structure
 ```
 BookSharingWebAPI/
+├── BookSharingApp.Cli/    # Admin CLI tool (report viewer)
+│   ├── Commands/          # Command implementations
+│   └── Formatting/        # Table output helpers
 ├── BookSharingApp.Tests/  # Unit test project (xUnit)
 │   ├── Helpers/           # Test utilities
 │   ├── Services/          # Service layer tests
@@ -417,6 +420,26 @@ The application uses environment variables for database configuration to keep cr
 - **DB_CONNECTION_STRING** - Full connection string for the application
 
 For local development, copy `.env.example` to `.env` and customize the values as needed.
+
+## Admin CLI Tool
+
+A read-only console application for viewing chat message reports. No new API endpoints — admin access is gated by server/SSH access.
+
+### Running via Docker (interactive)
+```bash
+docker compose exec -it booksharing-api admin
+```
+Then run commands at the `>>` prompt. The CLI picks up `ConnectionStrings__DefaultConnection` from the container automatically.
+
+### Running Locally
+```bash
+dotnet run --project BookSharingApp.Cli -- --connection-string "Host=localhost;Port=5432;Database=booksharingdb;Username=bookuser;Password=YOUR_PASSWORD"
+```
+
+### Commands
+- **`reports list [--user <name>]`** — List all reports (newest first), optionally filtered by reported user name
+- **`reports view <id>`** — Full report detail with share context (book title, lender/borrower, share status)
+- **`reports stats`** — Total count, breakdown by category, top reported users
 
 ## Related Projects
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 # Set the working directory
 WORKDIR /src
 
-# Copy the project file and restore dependencies
+# Copy project files and restore dependencies
 COPY BookSharingApp.csproj .
-RUN dotnet restore
+COPY BookSharingApp.Cli/BookSharingApp.Cli.csproj BookSharingApp.Cli/
+RUN dotnet restore BookSharingApp.csproj
+RUN dotnet restore BookSharingApp.Cli/BookSharingApp.Cli.csproj
 
 # Copy the rest of the source code
 COPY . .
@@ -17,6 +19,9 @@ RUN dotnet build BookSharingApp.csproj -c Release -o /app/build
 # Publish the application
 RUN dotnet publish BookSharingApp.csproj -c Release -o /app/publish
 
+# Publish the CLI tool
+RUN dotnet publish BookSharingApp.Cli/BookSharingApp.Cli.csproj -c Release -o /app/cli
+
 # Use the official .NET 8 runtime image for the final stage
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 
@@ -25,6 +30,11 @@ WORKDIR /app
 
 # Copy the published application from the build stage
 COPY --from=build /app/publish .
+COPY --from=build /app/cli ./cli
+
+# Add CLI shortcut
+RUN printf '#!/bin/sh\nexec dotnet /app/cli/BookSharingApp.Cli.dll "$@"\n' > /usr/local/bin/admin \
+    && chmod +x /usr/local/bin/admin
 
 # Expose port 8080
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -248,7 +248,56 @@ BookSharingWebAPI/
 ├── Services/       # Business logic layer
 ├── Validators/     # Business rule validators
 ├── wwwroot/images/ # Book cover thumbnails
+├── BookSharingApp.Cli/       # Admin CLI tool (report viewer)
 └── BookSharingApp.Tests/     # Unit tests (xUnit)
+```
+
+## Admin CLI
+
+A read-only command-line tool for viewing chat message reports. Admin access is gated by server/SSH access — no additional auth or API endpoints required.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `reports list` | List all reports (newest first) |
+| `reports list --user <name>` | Filter by reported user name |
+| `reports view <id>` | Full report detail with share context |
+| `reports stats` | Total count, breakdown by category, top reported users |
+
+### Usage (Docker)
+
+The CLI is included in the Docker image. Start an interactive session with `docker compose exec`, then run commands at the prompt. The connection string is picked up automatically from the container environment.
+
+```bash
+docker compose exec -it booksharing-api admin
+```
+
+```
+BookSharing Admin CLI
+Type 'help' for available commands, 'exit' to quit.
+
+>> reports list
+>> reports list --user "john"
+>> reports view 42
+>> reports stats
+>> exit
+```
+
+One-shot mode is also supported by passing commands directly:
+
+```bash
+docker compose exec booksharing-api admin reports stats
+```
+
+### Usage (Local)
+
+```bash
+# Interactive mode
+dotnet run --project BookSharingApp.Cli -- --connection-string "Host=localhost;Port=5432;Database=booksharingdb;Username=bookuser;Password=YOUR_PASSWORD"
+
+# One-shot mode
+dotnet run --project BookSharingApp.Cli -- --connection-string "Host=localhost;..." reports list
 ```
 
 ## Environment Variables

--- a/WebAPI.sln
+++ b/WebAPI.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BookSharingApp.Tests", "Boo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BookSharingApp.IntegrationTests", "BookSharingApp.IntegrationTests\BookSharingApp.IntegrationTests.csproj", "{8C73E337-057E-4DB9-9D20-9385DC996053}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BookSharingApp.Cli", "BookSharingApp.Cli\BookSharingApp.Cli.csproj", "{304DBBE5-4EB1-40E1-8314-6FE63DD578C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{8C73E337-057E-4DB9-9D20-9385DC996053}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8C73E337-057E-4DB9-9D20-9385DC996053}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C73E337-057E-4DB9-9D20-9385DC996053}.Release|Any CPU.Build.0 = Release|Any CPU
+		{304DBBE5-4EB1-40E1-8314-6FE63DD578C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{304DBBE5-4EB1-40E1-8314-6FE63DD578C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{304DBBE5-4EB1-40E1-8314-6FE63DD578C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{304DBBE5-4EB1-40E1-8314-6FE63DD578C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

- New `BookSharingApp.Cli` console project that connects directly to the database for read-only report viewing
- Interactive REPL mode — start with `docker compose exec -it booksharing-api admin`, then run commands at the `>>` prompt
- One-shot mode also supported for scripting (`admin reports stats`)
- Three commands: `reports list [--user <name>]`, `reports view <id>`, `reports stats`
- Included in the Docker image via an `admin` shortcut at `/usr/local/bin/admin`
- No new API endpoints, tables, or schema changes — admin access gated by server/SSH access

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)