### PR TITLE
feat(admin): add resolve/unresolve commands and resolved status to report CLI

### DIFF
--- a/BookSharingApp.Cli/Commands/ReportCommands.cs
+++ b/BookSharingApp.Cli/Commands/ReportCommands.cs
@@ -11,12 +11,15 @@ public static class ReportCommands
     private static string FormatName(string firstName, string lastName)
         => $"{firstName} {lastName}".Trim();
 
-    public static async Task ListAsync(ApplicationDbContext db, string? userFilter)
+    public static async Task ListAsync(ApplicationDbContext db, string? userFilter, bool showAll = false)
     {
         var query = db.ChatMessageReports
             .AsNoTracking()
             .OrderByDescending(r => r.CreatedAt)
             .AsQueryable();
+
+        if (!showAll)
+            query = query.Where(r => !r.IsResolved);
 
         if (!string.IsNullOrWhiteSpace(userFilter))
         {
@@ -32,6 +35,7 @@ public static class ReportCommands
                 r.Id,
                 r.CreatedAt,
                 r.Category,
+                r.IsResolved,
                 ReportedUser = r.ReportedUser.FirstName + " " + r.ReportedUser.LastName,
                 Reporter = r.Reporter.FirstName + " " + r.Reporter.LastName,
                 Preview = r.ReportedContent.Length > 50
@@ -45,12 +49,13 @@ public static class ReportCommands
             return;
         }
 
-        var headers = new[] { "ID", "Created", "Category", "Reported User", "Reporter", "Message Preview" };
+        var headers = new[] { "ID", "Created", "Category", "Resolved", "Reported User", "Reporter", "Message Preview" };
         var rows = reports.Select(r => new[]
         {
             r.Id.ToString(),
             r.CreatedAt.ToString("yyyy-MM-dd HH:mm"),
             r.Category.ToString(),
+            r.IsResolved ? "Yes" : "No",
             r.ReportedUser.Trim(),
             r.Reporter.Trim(),
             r.Preview
@@ -95,6 +100,7 @@ public static class ReportCommands
         Console.WriteLine(new string('─', 40));
         Console.WriteLine($"  Created:        {report.CreatedAt:yyyy-MM-dd HH:mm:ss} UTC");
         Console.WriteLine($"  Category:       {report.Category}");
+        Console.WriteLine($"  Resolved:       {(report.IsResolved ? "Yes" : "No")}");
         Console.WriteLine($"  Reported User:  {FormatName(report.ReportedUser.FirstName, report.ReportedUser.LastName)}");
         Console.WriteLine($"  Reporter:       {FormatName(report.Reporter.FirstName, report.Reporter.LastName)}");
         Console.WriteLine();
@@ -151,9 +157,14 @@ public static class ReportCommands
             .Where(u => userIds.Contains(u.Id))
             .ToDictionaryAsync(u => u.Id, u => $"{u.FirstName} {u.LastName}".Trim());
 
+        var resolved = await db.ChatMessageReports.AsNoTracking().CountAsync(r => r.IsResolved);
+        var unresolved = total - resolved;
+
         Console.WriteLine("Report Statistics");
         Console.WriteLine(new string('─', 40));
         Console.WriteLine($"  Total Reports: {total}");
+        Console.WriteLine($"  Resolved:      {resolved}");
+        Console.WriteLine($"  Unresolved:    {unresolved}");
         Console.WriteLine();
 
         Console.WriteLine("By Category:");
@@ -167,5 +178,24 @@ public static class ReportCommands
             var name = users.GetValueOrDefault(user.UserId, user.UserId);
             Console.WriteLine($"  {name,-25} {user.Count} report(s)");
         }
+    }
+
+    public static async Task ResolveAsync(ApplicationDbContext db, int reportId, bool resolved)
+    {
+        var report = await db.ChatMessageReports.FindAsync(reportId);
+        if (report is null)
+        {
+            Console.WriteLine($"Report #{reportId} not found.");
+            return;
+        }
+        if (report.IsResolved == resolved)
+        {
+            Console.WriteLine($"Report #{reportId} is already {(resolved ? "resolved" : "unresolved")}.");
+            return;
+        }
+
+        report.IsResolved = resolved;
+        await db.SaveChangesAsync();
+        Console.WriteLine($"Report #{reportId} marked as {(resolved ? "resolved" : "unresolved")}.");
     }
 }

--- a/BookSharingApp.Cli/Program.cs
+++ b/BookSharingApp.Cli/Program.cs
@@ -64,11 +64,12 @@ static async Task<int> RunCommandAsync(ApplicationDbContext db, string[] args)
         {
             case "reports list":
                 var userFilter = GetOptionValue(args, "--user");
-                await ReportCommands.ListAsync(db, userFilter);
+                var showAll = args.Contains("--all");
+                await ReportCommands.ListAsync(db, userFilter, showAll);
                 return 0;
 
-            case "reports view" when GetPositionalArg(args, 2) is { } idStr && int.TryParse(idStr, out var id):
-                await ReportCommands.ViewAsync(db, id);
+            case "reports view" when GetPositionalArg(args, 2) is { } viewIdStr && int.TryParse(viewIdStr, out var viewId):
+                await ReportCommands.ViewAsync(db, viewId);
                 return 0;
 
             case "reports view":
@@ -78,6 +79,22 @@ static async Task<int> RunCommandAsync(ApplicationDbContext db, string[] args)
             case "reports stats":
                 await ReportCommands.StatsAsync(db);
                 return 0;
+
+            case "reports resolve" when GetPositionalArg(args, 2) is { } resolveIdStr && int.TryParse(resolveIdStr, out var resolveId):
+                await ReportCommands.ResolveAsync(db, resolveId, resolved: true);
+                return 0;
+
+            case "reports resolve":
+                Console.Error.WriteLine("Usage: reports resolve <id>");
+                return 1;
+
+            case "reports unresolve" when GetPositionalArg(args, 2) is { } unresolveIdStr && int.TryParse(unresolveIdStr, out var unresolveId):
+                await ReportCommands.ResolveAsync(db, unresolveId, resolved: false);
+                return 0;
+
+            case "reports unresolve":
+                Console.Error.WriteLine("Usage: reports unresolve <id>");
+                return 1;
 
             default:
                 Console.Error.WriteLine($"Unknown command: {baseCommand}");
@@ -95,11 +112,13 @@ static async Task<int> RunCommandAsync(ApplicationDbContext db, string[] args)
 static void PrintHelp()
 {
     Console.WriteLine("Available commands:");
-    Console.WriteLine("  reports list [--user <name>]  List all reports (newest first)");
-    Console.WriteLine("  reports view <id>             View full details of a report");
-    Console.WriteLine("  reports stats                 Show report statistics");
-    Console.WriteLine("  help                          Show this help message");
-    Console.WriteLine("  exit                          Exit the CLI");
+    Console.WriteLine("  reports list [--all] [--user <name>]  List reports (unresolved by default)");
+    Console.WriteLine("  reports view <id>                     View full details of a report");
+    Console.WriteLine("  reports resolve <id>                  Mark a report as resolved");
+    Console.WriteLine("  reports unresolve <id>                Mark a report as unresolved");
+    Console.WriteLine("  reports stats                         Show report statistics");
+    Console.WriteLine("  help                                  Show this help message");
+    Console.WriteLine("  exit                                  Exit the CLI");
 }
 
 static string ResolveConnectionString(string[] args)


### PR DESCRIPTION
Closes #184

## Summary
- `reports resolve <id>` / `reports unresolve <id>` — new commands to toggle `IsResolved` on a report (no-ops if already in target state)
- `reports list` — defaults to unresolved only; `--all` flag shows everything; added Resolved column to table output
- `reports view <id>` — now shows Resolved status
- `reports stats` — now shows resolved/unresolved counts alongside total

🤖 Generated with [Claude Code](https://claude.com/claude-code)