### PR TITLE
feat(admin): add ban command to admin CLI tool

### DIFF
--- a/BookSharingApp.Cli/Commands/ReportCommands.cs
+++ b/BookSharingApp.Cli/Commands/ReportCommands.cs
@@ -180,6 +180,59 @@ public static class ReportCommands
         }
     }
 
+    public static async Task BanAsync(ApplicationDbContext db, int reportId)
+    {
+        var report = await db.ChatMessageReports
+            .Include(r => r.ReportedUser)
+            .FirstOrDefaultAsync(r => r.Id == reportId);
+
+        if (report is null)
+        {
+            Console.Error.WriteLine($"Report #{reportId} not found.");
+            return;
+        }
+
+        var user = report.ReportedUser;
+        if (user.LockoutEnd == DateTimeOffset.MaxValue)
+        {
+            Console.Error.WriteLine($"Reported user is already banned.");
+            return;
+        }
+
+        var name = FormatName(user.FirstName, user.LastName);
+        var preview = report.ReportedContent.Length > 60
+            ? report.ReportedContent[..60] + "..."
+            : report.ReportedContent;
+
+        Console.WriteLine($"Report:  #{report.Id}");
+        Console.WriteLine($"User:    {name} (id: {user.Id})");
+        Console.WriteLine($"Message: {preview}");
+        Console.Write($"Ban {name} (id: {user.Id})? This is permanent and cannot be undone. [y/N]: ");
+
+        var response = Console.ReadLine();
+        if (response is null || response.Trim().ToLower() != "y")
+        {
+            Console.WriteLine("Aborted.");
+            return;
+        }
+
+        await using var transaction = await db.Database.BeginTransactionAsync();
+        try
+        {
+            await UserCommands.ApplyBanAsync(db, user);
+            report.IsResolved = true;
+            await db.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+
+        Console.WriteLine($"User '{name}' has been banned and report #{reportId} has been resolved.");
+    }
+
     public static async Task ResolveAsync(ApplicationDbContext db, int reportId, bool resolved)
     {
         var report = await db.ChatMessageReports.FindAsync(reportId);

--- a/BookSharingApp.Cli/Commands/UserCommands.cs
+++ b/BookSharingApp.Cli/Commands/UserCommands.cs
@@ -1,0 +1,156 @@
+using BookSharingApp.Cli.Formatting;
+using BookSharingApp.Common;
+using BookSharingApp.Data;
+using BookSharingApp.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookSharingApp.Cli.Commands;
+
+public static class UserCommands
+{
+    public static async Task ListAsync(ApplicationDbContext db, string? search)
+    {
+        var query = db.Users.AsNoTracking().AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var filter = search.ToLower();
+            query = query.Where(u =>
+                (u.FirstName + " " + u.LastName).ToLower().Contains(filter));
+        }
+
+        var users = await query
+            .OrderBy(u => u.LastName)
+            .ThenBy(u => u.FirstName)
+            .Select(u => new
+            {
+                u.Id,
+                u.FirstName,
+                u.LastName,
+                u.Email
+            })
+            .ToListAsync();
+
+        if (users.Count == 0)
+        {
+            Console.WriteLine("No users found.");
+            return;
+        }
+
+        var headers = new[] { "ID", "Name", "Email" };
+        var rows = users.Select(u => new[]
+        {
+            u.Id,
+            $"{u.FirstName} {u.LastName}".Trim(),
+            u.Email ?? ""
+        }).ToList();
+
+        TableFormatter.Print(headers, rows, "user");
+    }
+
+    public static async Task BanAsync(ApplicationDbContext db, string userId)
+    {
+        var user = await db.Users.FindAsync(userId);
+        if (user is null)
+        {
+            Console.Error.WriteLine($"User '{userId}' not found.");
+            return;
+        }
+
+        if (user.LockoutEnd == DateTimeOffset.MaxValue)
+        {
+            Console.Error.WriteLine($"User '{userId}' is already banned.");
+            return;
+        }
+
+        var name = $"{user.FirstName} {user.LastName}".Trim();
+        Console.WriteLine($"User:  {name}");
+        Console.WriteLine($"ID:    {user.Id}");
+        Console.Write($"Ban {name} (id: {user.Id})? This is permanent and cannot be undone. [y/N]: ");
+
+        var response = Console.ReadLine();
+        if (response is null || (response.Trim().ToLower() != "y"))
+        {
+            Console.WriteLine("Aborted.");
+            return;
+        }
+
+        await using var transaction = await db.Database.BeginTransactionAsync();
+        try
+        {
+            await ApplyBanAsync(db, user);
+            await db.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+
+        Console.WriteLine($"User '{name}' has been banned.");
+    }
+
+    /// <summary>
+    /// Stages the ban (token revocation + PII scrub) without saving or managing the transaction.
+    /// The caller owns the transaction and must call SaveChangesAsync.
+    /// </summary>
+    public static async Task ApplyBanAsync(ApplicationDbContext db, BookSharingApp.Models.User user)
+    {
+        if (user.LockoutEnd == DateTimeOffset.MaxValue)
+            throw new InvalidOperationException($"User '{user.Id}' is already banned.");
+
+        var tokens = await db.RefreshTokens
+            .Where(rt => rt.UserId == user.Id)
+            .ToListAsync();
+        db.RefreshTokens.RemoveRange(tokens);
+
+        var chatMessages = await db.ChatMessages
+            .Where(m => m.SenderId == user.Id && !m.IsSystemMessage)
+            .ToListAsync();
+        foreach (var message in chatMessages)
+            message.Content = "[deleted]";
+
+        var userBooks = await db.UserBooks
+            .Where(ub => ub.UserId == user.Id && !ub.IsDeleted)
+            .ToListAsync();
+        foreach (var userBook in userBooks)
+        {
+            userBook.IsDeleted = true;
+            userBook.DeletedAt = DateTime.UtcNow;
+        }
+
+        // Decline only Requested shares — the book hasn't changed hands yet, so the share
+        // can be cleanly cancelled. Active shares (Ready, PickedUp, Returned) are mid-flight
+        // and need human resolution; auto-declining them would misrepresent physical reality.
+        // No notifications are sent because the CLI doesn't have INotificationService wired up;
+        // the "[Banned User]" name visible in share details serves as an implicit signal to
+        // the remaining participant.
+        var requestedShares = await db.Shares
+            .Include(s => s.UserBook)
+            .Where(s => s.Status == ShareStatus.Requested && !s.IsDisputed &&
+                        (s.Borrower == user.Id || s.UserBook.UserId == user.Id))
+            .ToListAsync();
+        foreach (var share in requestedShares)
+            share.Status = ShareStatus.Declined;
+
+        var memberships = await db.CommunityUsers
+            .Where(cu => cu.UserId == user.Id)
+            .ToListAsync();
+        foreach (var membership in memberships)
+        {
+            var memberCount = await db.CommunityUsers
+                .CountAsync(cu => cu.CommunityId == membership.CommunityId);
+            db.CommunityUsers.Remove(membership);
+
+            if (memberCount == 1)
+            {
+                var community = await db.Communities.FindAsync(membership.CommunityId);
+                if (community is not null)
+                    db.Communities.Remove(community);
+            }
+        }
+
+        UserPiiScrubber.Scrub(user, "Banned");
+    }
+}

--- a/BookSharingApp.Cli/Program.cs
+++ b/BookSharingApp.Cli/Program.cs
@@ -96,6 +96,27 @@ static async Task<int> RunCommandAsync(ApplicationDbContext db, string[] args)
                 Console.Error.WriteLine("Usage: reports unresolve <id>");
                 return 1;
 
+            case "reports ban" when GetPositionalArg(args, 2) is { } banReportIdStr && int.TryParse(banReportIdStr, out var banReportId):
+                await ReportCommands.BanAsync(db, banReportId);
+                return 0;
+
+            case "reports ban":
+                Console.Error.WriteLine("Usage: reports ban <reportId>");
+                return 1;
+
+            case "users list":
+                var userSearch = GetOptionValue(args, "--search");
+                await UserCommands.ListAsync(db, userSearch);
+                return 0;
+
+            case "users ban" when GetPositionalArg(args, 2) is { } banUserIdStr:
+                await UserCommands.BanAsync(db, banUserIdStr);
+                return 0;
+
+            case "users ban":
+                Console.Error.WriteLine("Usage: users ban <id>");
+                return 1;
+
             default:
                 Console.Error.WriteLine($"Unknown command: {baseCommand}");
                 Console.Error.WriteLine("Type 'help' for available commands.");
@@ -116,7 +137,10 @@ static void PrintHelp()
     Console.WriteLine("  reports view <id>                     View full details of a report");
     Console.WriteLine("  reports resolve <id>                  Mark a report as resolved");
     Console.WriteLine("  reports unresolve <id>                Mark a report as unresolved");
+    Console.WriteLine("  reports ban <reportId>                Ban reported user and resolve report");
     Console.WriteLine("  reports stats                         Show report statistics");
+    Console.WriteLine("  users list [--search <name>]          List users with banned status");
+    Console.WriteLine("  users ban <id>                        Permanently ban a user");
     Console.WriteLine("  help                                  Show this help message");
     Console.WriteLine("  exit                                  Exit the CLI");
 }

--- a/Services/UserDeletionService.cs
+++ b/Services/UserDeletionService.cs
@@ -134,17 +134,7 @@ namespace BookSharingApp.Services
                 _logger.LogDebug("Removed user {UserId} from {Count} communities", userId, communityMemberships.Count);
 
                 // Step 8: Scrub PII from the aspnetusers row in-place (tombstone)
-                user.Email = $"deleted-{userId}@deleted.invalid";
-                user.NormalizedEmail = $"DELETED-{userId.ToUpper()}@DELETED.INVALID";
-                user.UserName = $"deleted-{userId}";
-                user.NormalizedUserName = $"DELETED-{userId.ToUpper()}";
-                user.FirstName = "[Deleted";
-                user.LastName = "User]";
-                user.PhoneNumber = null;
-                user.PasswordHash = null;
-                user.SecurityStamp = Guid.NewGuid().ToString();
-                user.LockoutEnabled = true;
-                user.LockoutEnd = DateTimeOffset.MaxValue;
+                UserPiiScrubber.Scrub(user, "Deleted");
                 await _context.SaveChangesAsync();
 
                 await transaction.CommitAsync();

--- a/Services/UserPiiScrubber.cs
+++ b/Services/UserPiiScrubber.cs
@@ -1,0 +1,30 @@
+using BookSharingApp.Models;
+
+namespace BookSharingApp.Services;
+
+public static class UserPiiScrubber
+{
+    /// <summary>
+    /// Irreversibly scrubs PII from a user account and permanently locks it.
+    /// </summary>
+    /// <param name="user">The user to scrub (modified in-place).</param>
+    /// <param name="label">
+    /// A short label used to construct the tombstone display name, formatted as "[{label} User]".
+    /// Use "Deleted" for self-initiated account deletion and "Banned" for admin bans,
+    /// so the two cases are distinguishable in the database.
+    /// </param>
+    public static void Scrub(User user, string label)
+    {
+        user.Email = $"deleted-{user.Id}@deleted.invalid";
+        user.NormalizedEmail = $"DELETED-{user.Id.ToUpper()}@DELETED.INVALID";
+        user.UserName = $"deleted-{user.Id}";
+        user.NormalizedUserName = $"DELETED-{user.Id.ToUpper()}";
+        user.FirstName = $"[{label}";
+        user.LastName = "User]";
+        user.PhoneNumber = null;
+        user.PasswordHash = null;
+        user.SecurityStamp = Guid.NewGuid().ToString();
+        user.LockoutEnabled = true;
+        user.LockoutEnd = DateTimeOffset.MaxValue;
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts PII scrubbing logic from `UserDeletionService` into a new `UserPiiScrubber.Scrub(user, label)` helper — `"Deleted"` for self-initiated deletion, `"Banned"` for admin bans, so tombstones are distinguishable in the DB
- Adds `users list [--search <name>]` to find users by name before banning
- Adds `users ban <id>` to permanently ban a user with a confirmation prompt
- Adds `reports ban <reportId>` to ban the reported user and auto-resolve the report in a single transaction

The ban operation performs: PII scrub, refresh token revocation, chat message scrubbing, user book soft-deletion, auto-decline of pending `Requested` shares (both lender and borrower side), and community membership removal. Active shares (Ready/PickedUp/Returned) are left for human resolution.

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)