### PR TITLE
feat(notifications): add AdminWarning type and warn CLI commands

### DIFF
--- a/BookSharingApp.Cli/Commands/ReportCommands.cs
+++ b/BookSharingApp.Cli/Commands/ReportCommands.cs
@@ -193,7 +193,7 @@ public static class ReportCommands
         }
 
         var user = report.ReportedUser;
-        if (user.LockoutEnd == DateTimeOffset.MaxValue)
+        if (UserCommands.IsUserBanned(user))
         {
             Console.Error.WriteLine($"Reported user is already banned.");
             return;
@@ -231,6 +231,55 @@ public static class ReportCommands
         }
 
         Console.WriteLine($"User '{name}' has been banned and report #{reportId} has been resolved.");
+    }
+
+    public static async Task WarnAsync(ApplicationDbContext db, int reportId, string message)
+    {
+        var report = await db.ChatMessageReports
+            .Include(r => r.ReportedUser)
+            .FirstOrDefaultAsync(r => r.Id == reportId);
+
+        if (report is null)
+        {
+            Console.Error.WriteLine($"Report #{reportId} not found.");
+            return;
+        }
+
+        var user = report.ReportedUser;
+        if (UserCommands.IsUserBanned(user))
+        {
+            Console.Error.WriteLine($"Reported user is already banned.");
+            return;
+        }
+
+        var name = FormatName(user.FirstName, user.LastName);
+        var preview = report.ReportedContent.Length > 60
+            ? report.ReportedContent[..60] + "..."
+            : report.ReportedContent;
+
+        Console.WriteLine($"Report:  #{report.Id}");
+        Console.WriteLine($"User:    {name} (id: {user.Id})");
+        Console.WriteLine($"Message: {preview}");
+        Console.WriteLine($"Warning: {message}");
+        Console.Write($"Send warning to {name} and resolve report #{reportId}? [y/N]: ");
+
+        var response = Console.ReadLine();
+        if (response is null || response.Trim().ToLower() != "y")
+        {
+            Console.WriteLine("Aborted.");
+            return;
+        }
+
+        // Determine share context from the report's message thread (null if no share thread)
+        var shareId = await db.ChatMessageReports
+            .Where(r => r.Id == reportId)
+            .Select(r => r.Message.Thread.ShareChatThread != null ? (int?)r.Message.Thread.ShareChatThread.ShareId : null)
+            .FirstOrDefaultAsync();
+
+        await UserCommands.CommitWarnAsync(db, user.Id, message, shareId,
+            extraStaging: () => report.IsResolved = true);
+
+        Console.WriteLine($"Warning sent to '{name}' and report #{reportId} has been resolved.");
     }
 
     public static async Task ResolveAsync(ApplicationDbContext db, int reportId, bool resolved)

--- a/BookSharingApp.Cli/Commands/UserCommands.cs
+++ b/BookSharingApp.Cli/Commands/UserCommands.cs
@@ -1,6 +1,7 @@
 using BookSharingApp.Cli.Formatting;
 using BookSharingApp.Common;
 using BookSharingApp.Data;
+using BookSharingApp.Models;
 using BookSharingApp.Services;
 using Microsoft.EntityFrameworkCore;
 
@@ -48,6 +49,80 @@ public static class UserCommands
         TableFormatter.Print(headers, rows, "user");
     }
 
+    public static bool IsUserBanned(User user) => user.LockoutEnd == DateTimeOffset.MaxValue;
+
+    public static async Task WarnAsync(ApplicationDbContext db, string userId, string message)
+    {
+        var user = await db.Users.FindAsync(userId);
+        if (user is null)
+        {
+            Console.Error.WriteLine($"User '{userId}' not found.");
+            return;
+        }
+
+        if (IsUserBanned(user))
+        {
+            Console.Error.WriteLine($"User '{userId}' is banned and cannot receive warnings.");
+            return;
+        }
+
+        var name = $"{user.FirstName} {user.LastName}".Trim();
+        Console.WriteLine($"User:    {name} (id: {user.Id})");
+        Console.WriteLine($"Message: {message}");
+        Console.Write($"Send warning to {name}? [y/N]: ");
+
+        var response = Console.ReadLine();
+        if (response is null || response.Trim().ToLower() != "y")
+        {
+            Console.WriteLine("Aborted.");
+            return;
+        }
+
+        await CommitWarnAsync(db, user.Id, message, shareId: null);
+        Console.WriteLine($"Warning sent to '{name}'.");
+    }
+
+    /// <summary>
+    /// Creates an AdminWarning notification for the given user without saving or managing the transaction.
+    /// The caller owns the transaction and must call SaveChangesAsync.
+    /// Note: CreatedByUserId is set to the warned user's own ID because the CLI has no authenticated
+    /// admin identity. The mobile client should not display "created by" for AdminWarning notifications.
+    /// </summary>
+    public static void StageWarning(ApplicationDbContext db, string userId, string message, int? shareId)
+    {
+        db.Notifications.Add(new Notification
+        {
+            UserId = userId,
+            NotificationType = NotificationType.AdminWarning,
+            Message = message,
+            ShareId = shareId,
+            CreatedByUserId = userId,
+            CreatedAt = DateTime.UtcNow,
+            ReadAt = null
+        });
+    }
+
+    /// <summary>
+    /// Stages a warning and any additional work, then commits in a single transaction.
+    /// <paramref name="extraStaging"/> runs after StageWarning and before SaveChangesAsync.
+    /// </summary>
+    public static async Task CommitWarnAsync(ApplicationDbContext db, string userId, string message, int? shareId, Action? extraStaging = null)
+    {
+        await using var transaction = await db.Database.BeginTransactionAsync();
+        try
+        {
+            StageWarning(db, userId, message, shareId);
+            extraStaging?.Invoke();
+            await db.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
     public static async Task BanAsync(ApplicationDbContext db, string userId)
     {
         var user = await db.Users.FindAsync(userId);
@@ -57,7 +132,7 @@ public static class UserCommands
             return;
         }
 
-        if (user.LockoutEnd == DateTimeOffset.MaxValue)
+        if (IsUserBanned(user))
         {
             Console.Error.WriteLine($"User '{userId}' is already banned.");
             return;
@@ -95,7 +170,7 @@ public static class UserCommands
     /// Stages the ban (token revocation + PII scrub) without saving or managing the transaction.
     /// The caller owns the transaction and must call SaveChangesAsync.
     /// </summary>
-    public static async Task ApplyBanAsync(ApplicationDbContext db, BookSharingApp.Models.User user)
+    public static async Task ApplyBanAsync(ApplicationDbContext db, User user)
     {
         if (user.LockoutEnd == DateTimeOffset.MaxValue)
             throw new InvalidOperationException($"User '{user.Id}' is already banned.");

--- a/BookSharingApp.Cli/Program.cs
+++ b/BookSharingApp.Cli/Program.cs
@@ -104,6 +104,20 @@ static async Task<int> RunCommandAsync(ApplicationDbContext db, string[] args)
                 Console.Error.WriteLine("Usage: reports ban <reportId>");
                 return 1;
 
+            case "reports warn" when GetPositionalArg(args, 2) is { } warnReportIdStr && int.TryParse(warnReportIdStr, out var warnReportId):
+                var warnReportMessage = GetMessageValue(args);
+                if (string.IsNullOrWhiteSpace(warnReportMessage))
+                {
+                    Console.Error.WriteLine("Usage: reports warn <reportId> --message <message>");
+                    return 1;
+                }
+                await ReportCommands.WarnAsync(db, warnReportId, warnReportMessage);
+                return 0;
+
+            case "reports warn":
+                Console.Error.WriteLine("Usage: reports warn <reportId> --message <message>");
+                return 1;
+
             case "users list":
                 var userSearch = GetOptionValue(args, "--search");
                 await UserCommands.ListAsync(db, userSearch);
@@ -115,6 +129,20 @@ static async Task<int> RunCommandAsync(ApplicationDbContext db, string[] args)
 
             case "users ban":
                 Console.Error.WriteLine("Usage: users ban <id>");
+                return 1;
+
+            case "users warn" when GetPositionalArg(args, 2) is { } warnUserIdStr:
+                var warnUserMessage = GetMessageValue(args);
+                if (string.IsNullOrWhiteSpace(warnUserMessage))
+                {
+                    Console.Error.WriteLine("Usage: users warn <userId> --message <message>");
+                    return 1;
+                }
+                await UserCommands.WarnAsync(db, warnUserIdStr, warnUserMessage);
+                return 0;
+
+            case "users warn":
+                Console.Error.WriteLine("Usage: users warn <id> --message <message>");
                 return 1;
 
             default:
@@ -138,9 +166,11 @@ static void PrintHelp()
     Console.WriteLine("  reports resolve <id>                  Mark a report as resolved");
     Console.WriteLine("  reports unresolve <id>                Mark a report as unresolved");
     Console.WriteLine("  reports ban <reportId>                Ban reported user and resolve report");
+    Console.WriteLine("  reports warn <reportId> --message <> Warn reported user and resolve report");
     Console.WriteLine("  reports stats                         Show report statistics");
     Console.WriteLine("  users list [--search <name>]          List users with banned status");
     Console.WriteLine("  users ban <id>                        Permanently ban a user");
+    Console.WriteLine("  users warn <id> --message <>          Send a warning to a user");
     Console.WriteLine("  help                                  Show this help message");
     Console.WriteLine("  exit                                  Exit the CLI");
 }
@@ -168,6 +198,14 @@ static ApplicationDbContext CreateDbContext(string connectionString)
         .Options;
 
     return new ApplicationDbContext(options);
+}
+
+static string? GetMessageValue(string[] args)
+{
+    var value = GetOptionValue(args, "--message");
+    if (string.IsNullOrWhiteSpace(value))
+        return null;
+    return value.Replace("\\n", "\n");
 }
 
 static string? GetOptionValue(string[] args, string optionName)

--- a/BookSharingApp.Tests/Services/NotificationServiceTests.cs
+++ b/BookSharingApp.Tests/Services/NotificationServiceTests.cs
@@ -2087,5 +2087,100 @@ namespace BookSharingApp.Tests.Services
                 await act.Should().NotThrowAsync();
             }
         }
+
+        public class MarkNotificationAsReadAsyncTests : NotificationServiceTestBase
+        {
+            [Fact]
+            public async Task WithUnreadNotification_SetsReadAt()
+            {
+                // Arrange
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var notificationService = new NotificationService(context, LoggerMock.Object);
+
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                await context.SaveChangesAsync();
+
+                var notification = TestDataBuilder.CreateNotification(userId: user.Id, readAt: null);
+                context.Notifications.Add(notification);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await notificationService.MarkNotificationAsReadAsync(notification.Id, user.Id);
+
+                // Assert
+                result.Should().BeTrue();
+                var updated = await context.Notifications.FindAsync(notification.Id);
+                updated!.ReadAt.Should().NotBeNull();
+            }
+
+            [Fact]
+            public async Task WithAlreadyReadNotification_ReturnsTrueWithoutUpdating()
+            {
+                // Arrange
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var notificationService = new NotificationService(context, LoggerMock.Object);
+
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                await context.SaveChangesAsync();
+
+                var originalReadAt = DateTime.UtcNow.AddHours(-1);
+                var notification = TestDataBuilder.CreateNotification(userId: user.Id, readAt: originalReadAt);
+                context.Notifications.Add(notification);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await notificationService.MarkNotificationAsReadAsync(notification.Id, user.Id);
+
+                // Assert
+                result.Should().BeTrue();
+                var updated = await context.Notifications.FindAsync(notification.Id);
+                updated!.ReadAt.Should().Be(originalReadAt);
+            }
+
+            [Fact]
+            public async Task WithNotificationBelongingToOtherUser_ReturnsFalse()
+            {
+                // Arrange
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var notificationService = new NotificationService(context, LoggerMock.Object);
+
+                var owner = TestDataBuilder.CreateUser(id: "owner-1");
+                var otherUser = TestDataBuilder.CreateUser(id: "other-1");
+                context.Users.AddRange(owner, otherUser);
+                await context.SaveChangesAsync();
+
+                var notification = TestDataBuilder.CreateNotification(userId: owner.Id, readAt: null);
+                context.Notifications.Add(notification);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await notificationService.MarkNotificationAsReadAsync(notification.Id, otherUser.Id);
+
+                // Assert
+                result.Should().BeFalse();
+                var unchanged = await context.Notifications.FindAsync(notification.Id);
+                unchanged!.ReadAt.Should().BeNull();
+            }
+
+            [Fact]
+            public async Task WithNonExistentNotification_ReturnsFalse()
+            {
+                // Arrange
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var notificationService = new NotificationService(context, LoggerMock.Object);
+
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                context.Users.Add(user);
+                await context.SaveChangesAsync();
+
+                // Act
+                var result = await notificationService.MarkNotificationAsReadAsync(999, user.Id);
+
+                // Assert
+                result.Should().BeFalse();
+            }
+        }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,11 +305,12 @@ Stores reports submitted by share participants about inappropriate chat messages
 - Users cannot report their own messages
 
 ### Notification
-- **Types**: ShareStatusChanged, ShareDueDateChanged, ShareMessageReceived
+- **Types**: ShareStatusChanged, ShareDueDateChanged, ShareMessageReceived, UserBookWithdrawn, AdminWarning
 - Separate read tracking for share vs. chat notifications
 - Includes share details, message content, and actor information
 - Auto-created when share status changes or messages are sent
 - Persists even if share is archived
+- **AdminWarning** — sent by admins via CLI to warn a user about their behavior. Optionally scoped to a share. `CreatedByUserId` is a self-reference (the warned user's own ID) because the CLI has no authenticated admin identity. Mobile client should display this type as a blocking modal and should not show the "created by" field.
 
 ## API Endpoint Reference
 
@@ -352,6 +353,7 @@ Stores reports submitted by share participants about inappropriate chat messages
 
 ### Notifications (`/notifications`)
 - `GET /notifications` - Get all unread notifications
+- `PATCH /notifications/{id}/read` - Mark a single notification as read by ID (for AdminWarning dismissal)
 - `PATCH /notifications/shares/{shareId}/read` - Mark share notifications read
 - `PATCH /notifications/shares/{shareId}/chat/read` - Mark chat notifications read
 

--- a/Common/NotificationType.cs
+++ b/Common/NotificationType.cs
@@ -6,5 +6,6 @@ namespace BookSharingApp.Common
         public const string ShareDueDateChanged = "ShareDueDateChanged";
         public const string ShareMessageReceived = "ShareMessageReceived";
         public const string UserBookWithdrawn = "UserBookWithdrawn";
+        public const string AdminWarning = "AdminWarning";
     }
 }

--- a/Endpoints/NotificationEndpoints.cs
+++ b/Endpoints/NotificationEndpoints.cs
@@ -46,6 +46,19 @@ namespace BookSharingApp.Endpoints
             .WithName("GetUnreadNotifications")
             .WithOpenApi();
 
+            // PATCH /notifications/{id}/read - Mark a single notification as read
+            notifications.MapPatch("/{id:int}/read", async (int id,
+                HttpContext httpContext, INotificationService notificationService) =>
+            {
+                var currentUserId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)!.Value;
+
+                var found = await notificationService.MarkNotificationAsReadAsync(id, currentUserId);
+
+                return found ? Results.NoContent() : Results.NotFound();
+            })
+            .WithName("MarkNotificationAsRead")
+            .WithOpenApi();
+
             // PATCH /notifications/shares/{shareId}/read - Mark share notifications as read
             notifications.MapPatch("/shares/{shareId:int}/read", async (int shareId,
                 HttpContext httpContext, INotificationService notificationService) =>

--- a/Services/INotificationService.cs
+++ b/Services/INotificationService.cs
@@ -21,5 +21,11 @@ namespace BookSharingApp.Services
         /// <param name="shareId">The ID of the share.</param>
         /// <param name="userId">The ID of the user whose notifications should be marked as read.</param>
         Task MarkAllShareNotificationsAsReadForUserAsync(int shareId, string userId);
+
+        /// <summary>
+        /// Marks a single notification as read by ID. Returns false if the notification is not found
+        /// or does not belong to the given user.
+        /// </summary>
+        Task<bool> MarkNotificationAsReadAsync(int notificationId, string userId);
     }
 }

--- a/Services/NotificationService.cs
+++ b/Services/NotificationService.cs
@@ -69,6 +69,9 @@ namespace BookSharingApp.Services
 
         public async Task<List<Notification>> GetUnreadNotificationsAsync(string userId)
         {
+            // Note: for AdminWarning notifications CreatedByUser is a self-reference
+            // (CreatedByUserId == UserId). The mobile client should not display the
+            // "created by" field for that notification type.
             return await _context.Notifications
                 .Include(n => n.Share)
                     .ThenInclude(s => s!.UserBook)
@@ -150,6 +153,24 @@ namespace BookSharingApp.Services
                 _logger.LogInformation("Marked {Count} notifications as read for user {UserId} on share {ShareId} during archive",
                     notifications.Count, userId, shareId);
             }
+        }
+
+        public async Task<bool> MarkNotificationAsReadAsync(int notificationId, string userId)
+        {
+            var notification = await _context.Notifications
+                .FirstOrDefaultAsync(n => n.Id == notificationId && n.UserId == userId);
+
+            if (notification is null)
+                return false;
+
+            if (notification.ReadAt is null)
+            {
+                notification.ReadAt = DateTime.UtcNow;
+                await _context.SaveChangesAsync();
+                _logger.LogInformation("Marked notification {NotificationId} as read for user {UserId}", notificationId, userId);
+            }
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #190

## Summary

- Adds `AdminWarning` notification type; mobile client should present this as a blocking modal requiring manual dismissal
- Adds `PATCH /notifications/{id}/read` endpoint for dismissing individual notifications (the existing share-scoped routes don't cover warnings without a share)
- Adds `users warn <userId> --message <msg>` and `reports warn <reportId> --message <msg>` CLI commands; the `reports warn` variant warns the reported user and resolves the report in a single transaction, mirroring the `reports ban` pattern
- Supports `\n` escape sequences in `--message` for multi-line warnings
- Extracts `IsUserBanned` and `CommitWarnAsync` helpers to consolidate duplicated logic across warn and ban commands
- Unit tests for `MarkNotificationAsReadAsync` covering the ownership check, idempotency, and not-found cases
- CLAUDE.md updated with `AdminWarning` semantics (self-referential `CreatedByUserId`, blocking modal guidance for mobile) and the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)