### PR TITLE
feat(users): add GET /users/{userId}/reputation endpoint

### DIFF
--- a/BookSharingApp.Tests/Services/UserServiceTests.cs
+++ b/BookSharingApp.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,236 @@
+using BookSharingApp.Common;
+using BookSharingApp.Services;
+using BookSharingApp.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BookSharingApp.Tests.Services
+{
+    public class UserServiceTests
+    {
+        public abstract class UserServiceTestBase : IDisposable
+        {
+            protected readonly Mock<ILogger<UserService>> LoggerMock;
+
+            protected UserServiceTestBase()
+            {
+                LoggerMock = new Mock<ILogger<UserService>>();
+            }
+
+            public void Dispose() { }
+        }
+
+        public class GetUserReputationAsyncTests : UserServiceTestBase
+        {
+            [Fact]
+            public async Task GetUserReputationAsync_ReturnsZerosWhenUserHasNoShares()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var result = await service.GetUserReputationAsync("unknown-user", "borrower");
+
+                result.CompletedCount.Should().Be(0);
+                result.DisputeCount.Should().Be(0);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_BorrowerRole_CountsHomeSafeSharesAsCompleted()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+                context.Users.Add(borrower);
+                await context.SaveChangesAsync();
+
+                // Share one UserBook instance across both shares so EF doesn't get a duplicate stub
+                var userBook = TestDataBuilder.CreateUserBook();
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, userBook: userBook, status: ShareStatus.HomeSafe));
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, userBook: userBook, status: ShareStatus.HomeSafe));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(borrower.Id, "borrower");
+
+                result.CompletedCount.Should().Be(2);
+                result.DisputeCount.Should().Be(0);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_BorrowerRole_CountsIsDisputedSharesAsDisputes()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+                context.Users.Add(borrower);
+                await context.SaveChangesAsync();
+
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, isDisputed: true));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(borrower.Id, "borrower");
+
+                result.CompletedCount.Should().Be(0);
+                result.DisputeCount.Should().Be(1);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_BorrowerRole_DoesNotCountInProgressShares()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+                context.Users.Add(borrower);
+                await context.SaveChangesAsync();
+
+                var userBook = TestDataBuilder.CreateUserBook();
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, userBook: userBook, status: ShareStatus.Requested));
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, userBook: userBook, status: ShareStatus.Ready));
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, userBook: userBook, status: ShareStatus.PickedUp));
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, userBook: userBook, status: ShareStatus.Returned));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(borrower.Id, "borrower");
+
+                result.CompletedCount.Should().Be(0);
+                result.DisputeCount.Should().Be(0);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_BorrowerRole_DoesNotCountDeclinedShares()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+                context.Users.Add(borrower);
+                await context.SaveChangesAsync();
+
+                context.Shares.Add(TestDataBuilder.CreateShare(borrowerUser: borrower, status: ShareStatus.Declined));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(borrower.Id, "borrower");
+
+                result.CompletedCount.Should().Be(0);
+                result.DisputeCount.Should().Be(0);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_BorrowerRole_ArchivedHomeSafeSharesStillCount()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var borrower = TestDataBuilder.CreateUser(id: "borrower-1");
+                context.Users.Add(borrower);
+                await context.SaveChangesAsync();
+
+                var share = TestDataBuilder.CreateShare(borrowerUser: borrower, status: ShareStatus.HomeSafe);
+                context.Shares.Add(share);
+                await context.SaveChangesAsync();
+
+                // Archive the share — reputation count must be unaffected
+                context.ShareUserStates.Add(TestDataBuilder.CreateShareUserState(
+                    shareId: share.Id,
+                    share: share,
+                    userId: borrower.Id,
+                    user: borrower,
+                    isArchived: true,
+                    archivedAt: DateTime.UtcNow
+                ));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(borrower.Id, "borrower");
+
+                result.CompletedCount.Should().Be(1);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_LenderRole_CountsHomeSafeSharesAsCompleted()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var lender = TestDataBuilder.CreateUser(id: "lender-1");
+                var book = TestDataBuilder.CreateBook();
+                var userBook = TestDataBuilder.CreateUserBook(userId: lender.Id, user: lender, book: book);
+
+                context.Users.Add(lender);
+                context.Books.Add(book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                // Use distinct borrower IDs so EF doesn't conflict on BorrowerUser stubs
+                context.Shares.Add(TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id, userBook: userBook,
+                    borrower: "borrower-1", status: ShareStatus.HomeSafe));
+                context.Shares.Add(TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id, userBook: userBook,
+                    borrower: "borrower-2", status: ShareStatus.HomeSafe));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(lender.Id, "lender");
+
+                result.CompletedCount.Should().Be(2);
+                result.DisputeCount.Should().Be(0);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_LenderRole_CountsIsDisputedSharesAsDisputes()
+            {
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var lender = TestDataBuilder.CreateUser(id: "lender-1");
+                var book = TestDataBuilder.CreateBook();
+                var userBook = TestDataBuilder.CreateUserBook(userId: lender.Id, user: lender, book: book);
+
+                context.Users.Add(lender);
+                context.Books.Add(book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                context.Shares.Add(TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id, userBook: userBook,
+                    borrower: "borrower-1", isDisputed: true));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(lender.Id, "lender");
+
+                result.CompletedCount.Should().Be(0);
+                result.DisputeCount.Should().Be(1);
+            }
+
+            [Fact]
+            public async Task GetUserReputationAsync_BorrowerStatsDoNotIncludeLenderShares()
+            {
+                // A user's HomeSafe shares as lender must not appear in their borrower reputation
+                using var context = DbContextHelper.CreateInMemoryContext();
+                var service = new UserService(context, LoggerMock.Object);
+
+                var user = TestDataBuilder.CreateUser(id: "user-1");
+                var book = TestDataBuilder.CreateBook();
+                var userBook = TestDataBuilder.CreateUserBook(userId: user.Id, user: user, book: book);
+
+                context.Users.Add(user);
+                context.Books.Add(book);
+                context.UserBooks.Add(userBook);
+                await context.SaveChangesAsync();
+
+                // Share where user is the lender
+                context.Shares.Add(TestDataBuilder.CreateShare(
+                    userBookId: userBook.Id, userBook: userBook,
+                    borrower: "borrower-1", status: ShareStatus.HomeSafe));
+                await context.SaveChangesAsync();
+
+                var result = await service.GetUserReputationAsync(user.Id, "borrower");
+
+                result.CompletedCount.Should().Be(0);
+                result.DisputeCount.Should().Be(0);
+            }
+        }
+    }
+}

--- a/Data/DatabaseSeeder.cs
+++ b/Data/DatabaseSeeder.cs
@@ -258,6 +258,30 @@ namespace BookSharingApp.Data
                     Borrower = "user-001",
                     ReturnDate = null,
                     Status = ShareStatus.Ready
+                },
+
+                // Reputation test data: Jane (user-003) borrowing from John (user-002)
+                // Two completed borrows and one disputed, so the reputation endpoint has
+                // meaningful data on a fresh database.
+                new Share
+                {
+                    UserBookId = 5,  // user-002's The Great Gatsby
+                    Borrower = "user-003",
+                    Status = ShareStatus.HomeSafe
+                },
+                new Share
+                {
+                    UserBookId = 6,  // user-002's Last Argument of Kings
+                    Borrower = "user-003",
+                    Status = ShareStatus.HomeSafe
+                },
+                new Share
+                {
+                    UserBookId = 7,  // user-002's Before They Are Hanged
+                    Borrower = "user-003",
+                    Status = ShareStatus.PickedUp,
+                    IsDisputed = true,
+                    DisputedBy = "user-002"
                 }
             };
 

--- a/Endpoints/UserEndpoints.cs
+++ b/Endpoints/UserEndpoints.cs
@@ -1,0 +1,24 @@
+using BookSharingApp.Services;
+
+namespace BookSharingApp.Endpoints
+{
+    public static class UserEndpoints
+    {
+        public static void MapUserEndpoints(this WebApplication app)
+        {
+            var users = app.MapGroup("/users").WithTags("Users").RequireAuthorization();
+
+            // GET /users/{userId}/reputation?role=borrower|lender
+            users.MapGet("/{userId}/reputation", async (string userId, string role, IUserService userService) =>
+            {
+                if (role != "borrower" && role != "lender")
+                    return Results.BadRequest("role must be 'borrower' or 'lender'");
+
+                var reputation = await userService.GetUserReputationAsync(userId, role);
+                return Results.Ok(reputation);
+            })
+            .WithName("GetUserReputation")
+            .WithOpenApi();
+        }
+    }
+}

--- a/Models/UserDtos.cs
+++ b/Models/UserDtos.cs
@@ -1,0 +1,4 @@
+namespace BookSharingApp.Models
+{
+    public record UserReputationDto(int CompletedCount, int DisputeCount);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -116,6 +116,7 @@ builder.Services.AddScoped<IShareService, ShareService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IUserBookService, UserBookService>();
 builder.Services.AddScoped<IUserDeletionService, UserDeletionService>();
+builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddSingleton<IRateLimitService, RateLimitService>();
 builder.Services.AddSingleton<IRateLimiter>(provider =>
 {
@@ -226,6 +227,7 @@ app.MapUserBookEndpoints();
 app.MapShareEndpoints();
 app.MapChatEndpoints();
 app.MapNotificationEndpoints();
+app.MapUserEndpoints();
 app.MapLegalEndpoints();
 
 // Map SignalR hub

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -1,0 +1,9 @@
+using BookSharingApp.Models;
+
+namespace BookSharingApp.Services
+{
+    public interface IUserService
+    {
+        Task<UserReputationDto> GetUserReputationAsync(string userId, string role);
+    }
+}

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -1,0 +1,35 @@
+using BookSharingApp.Common;
+using BookSharingApp.Data;
+using BookSharingApp.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace BookSharingApp.Services
+{
+    public class UserService : IUserService
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ILogger<UserService> _logger;
+
+        public UserService(ApplicationDbContext context, ILogger<UserService> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<UserReputationDto> GetUserReputationAsync(string userId, string role)
+        {
+            IQueryable<Share> query = role == "borrower"
+                ? _context.Shares.Where(s => s.Borrower == userId)
+                : _context.Shares.Where(s => s.UserBook.UserId == userId);
+
+            var completedCount = await query.CountAsync(s => s.Status == ShareStatus.HomeSafe);
+            var disputeCount = await query.CountAsync(s => s.IsDisputed);
+
+            _logger.LogDebug("Reputation for user {UserId} role={Role}: completed={CompletedCount} disputes={DisputeCount}",
+                userId, role, completedCount, disputeCount);
+
+            return new UserReputationDto(completedCount, disputeCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /users/{userId}/reputation?role=borrower|lender` returning `{ completedCount, disputeCount }`
- New `UserService` / `IUserService` owns the reputation query — keeps it out of `ShareService`
- 9 unit tests covering borrower role, lender role, edge cases (archived shares, declined shares, role isolation)

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)